### PR TITLE
Link crates.io badge to crates.io page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Argh
 **Argh is an opinionated Derive-based argument parser optimized for code size**
 
-![crates.io](https://img.shields.io/crates/v/argh.svg)
+[![crates.io](https://img.shields.io/crates/v/argh.svg)](https://crates.io/crates/argh)
 
 Derive-based argument parsing optimized for code size and conformance
 to the Fuchsia commandline tools specification


### PR DESCRIPTION
Thank you for sharing this package. 🙂 I clicked on the crates.io badge expecting to go to [the crates.io page](https://crates.io/crates/argh), which I believe is conventional, but GitHub linked it to the badge image instead. Consider adding this link.