### PR TITLE
Tidy up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If more customized parsing is required, you can supply a custom
 `fn(&str) -> Result<T, String>` using the `from_str_fn` attribute:
 
 ```
-# use argh::FromArgs;
+use argh::FromArgs;
 
 #[derive(FromArgs)]
 /// Goofy thing.
@@ -106,43 +106,7 @@ Subcommands are also supported. To use a subcommand, declare a separate
 over each command:
 
 ```rust
-# use argh::FromArgs;
-
-#[derive(FromArgs, PartialEq, Debug)]
-/// Top-level command.
-struct TopLevel {
-    #[argh(subcommand)]
-    nested: MySubCommandEnum,
-}
-
-#[derive(FromArgs, PartialEq, Debug)]
-#[argh(subcommand)]
-enum MySubCommandEnum {
-    One(SubCommandOne),
-    Two(SubCommandTwo),
-}
-
-#[derive(FromArgs, PartialEq, Debug)]
-/// First subcommand.
-#[argh(subcommand, name = "one")]
-struct SubCommandOne {
-    #[argh(option)]
-    /// how many x
-    x: usize,
-}
-
-#[derive(FromArgs, PartialEq, Debug)]
-/// Second subcommand.
-#[argh(subcommand, name = "two")]
-struct SubCommandTwo {
-    #[argh(switch)]
-    /// whether to fooey
-    fooey: bool,
-}
-
-
-```rust
-# use argh::FromArgs;
+use argh::FromArgs;
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// Top-level command.


### PR DESCRIPTION
Remove `#`'s before use statements and remove duplication in the last block