### PR TITLE
Confusing syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fn main() {
 
 `./some_bin --help` will then output the following:
 
-```bash
+```
 Usage: cmdname [-j] --height <height> [--pilot-nickname <pilot-nickname>]
 
 Reach new heights.


### PR DESCRIPTION
The text isn't actually bash. The hightlighted `for` and `<>` confused me a little.

I thought argh does this coloring on purpose