### PR TITLE
Fix the source of the docs.rs badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/argh.svg)](https://crates.io/crates/argh)
 [![license](https://img.shields.io/badge/license-BSD3.0-blue.svg)](https://github.com/google/argh/LICENSE)
-[![docs.rs](https://docs.rs/com/badge.svg)](https://docs.rs/crate/argh/)
+[![docs.rs](https://docs.rs/argh/badge.svg)](https://docs.rs/crate/argh/)
 ![Argh](https://github.com/google/argh/workflows/Argh/badge.svg)
 
 Derive-based argument parsing optimized for code size and conformance


### PR DESCRIPTION
**issue:**

The current docs.rs badge image link points to https://docs.rs/com/badge.svg instead of https://docs.rs/argh/badge.svg

**fix:**

Modify the readme so the above badge image url points to the correct crate ('argh' instead of 'com').