### PR TITLE
Add missing newline to error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,6 +525,9 @@ impl MissingRequirements {
         }
 
         if !self.options.is_empty() {
+            if !self.positional_args.is_empty() {
+                output.push_str("\n");
+            }
             output.push_str("Required options not provided:");
             for option in &self.options {
                 output.push_str(NEWLINE_INDENT);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -306,6 +306,37 @@ Options:
 
     #[derive(FromArgs, Debug, PartialEq)]
     /// Woot
+    struct WithOption {
+        #[argh(positional)]
+        /// fooey
+        a: String,
+        #[argh(option)]
+        /// fooey
+        b: String,
+    }
+
+    #[test]
+    fn mixed_with_option() {
+        assert_output(
+            &["first", "--b", "foo"],
+            WithOption {
+                a: "first".into(),
+                b: "foo".into(),
+            },
+        );
+
+        assert_error::<WithOption>(
+            &[],
+            r###"Required positional arguments not provided:
+    a
+Required options not provided:
+    --b
+"###,
+        );
+    }
+
+    #[derive(FromArgs, Debug, PartialEq)]
+    /// Woot
     struct WithSubcommand {
         #[argh(positional)]
         /// fooey


### PR DESCRIPTION
 If both positional and optional args are present the error message was missing a newline.

Closes #45.