### PR TITLE
Introduce 'cargo bloat' action step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,3 +15,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run cargo bloat
+      uses: orf/cargo-bloat-action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -317,13 +317,7 @@ Options:
 
     #[test]
     fn mixed_with_option() {
-        assert_output(
-            &["first", "--b", "foo"],
-            WithOption {
-                a: "first".into(),
-                b: "foo".into(),
-            },
-        );
+        assert_output(&["first", "--b", "foo"], WithOption { a: "first".into(), b: "foo".into() });
 
         assert_error::<WithOption>(
             &[],


### PR DESCRIPTION
This commit introduces the [cargo-bloat](https://github.com/marketplace/actions/cargo-bloat)
step into the `Argh` action. The purpose of bloat is to observe the size of produced artifacts
over time and report on PRs etc how the size is changing.

Resolves #39