### PR TITLE
Expose HelpMessage and allow for custom help switches

### DIFF
--- a/argh_derive/src/errors.rs
+++ b/argh_derive/src/errors.rs
@@ -91,6 +91,7 @@ impl Errors {
         (expect_lit_str, LitStr, Str, "string"),
         (expect_lit_char, LitChar, Char, "character"),
         (expect_lit_int, LitInt, Int, "integer"),
+		(expect_lit_bool, LitBool, Bool, "boolean"),
     ];
 
     expect_meta_fn![

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -21,7 +21,7 @@ const SECTION_SEPARATOR: &str = "\n\n";
 /// in favor of the `subcommand` argument.
 pub(crate) fn help(
     errors: &Errors,
-    cmd_name_str_array_ident: syn::Ident,
+    ty_ident: &syn::Ident,
     ty_attrs: &TypeAttrs,
     fields: &[StructField<'_>],
     subcommand: Option<&StructField<'_>>,
@@ -98,10 +98,14 @@ pub(crate) fn help(
 
     format_lit.push_str("\n");
 
-    quote! { {
-        #subcommand_calculation
-        format!(#format_lit, command_name = #cmd_name_str_array_ident.join(" "), #subcommand_format_arg)
-    } }
+    quote! {
+		impl ::argh::HelpMessage for #ty_ident {
+			fn help_message(command_name: &[&str]) -> String {
+				#subcommand_calculation
+				format!(#format_lit, command_name = command_name.join(" "), #subcommand_format_arg)
+			}
+		}
+	}
 }
 
 /// A section composed of exactly just the literals provided to the program.

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -62,8 +62,10 @@ pub(crate) fn help(
     for option in options {
         option_description(errors, &mut format_lit, option);
     }
-    // Also include "help"
-    option_description_format(&mut format_lit, None, "--help", "display usage information");
+    // Also include "help" unless it has been disabled
+	if !ty_attrs.disable_help.as_ref().map(|lit_bool| lit_bool.value).unwrap_or(false) {
+		option_description_format(&mut format_lit, None, "--help", "display usage information");
+	}
 
     let subcommand_calculation;
     let subcommand_format_arg;

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -305,6 +305,7 @@ fn impl_from_args_struct(
     // Identifier referring to a value containing the name of the current command as an `&[&str]`.
     let cmd_name_str_array_ident = syn::Ident::new("__cmd_name", impl_span.clone());
     let help_impl = help::help(errors, name, type_attrs, &fields, subcommand);
+	let disable_help = type_attrs.disable_help.clone().unwrap_or_else(|| syn::LitBool { value: false, span: impl_span.clone() });
 
     let trait_impl = quote_spanned! { impl_span =>
         impl argh::FromArgs for #name {
@@ -328,7 +329,7 @@ fn impl_from_args_struct(
                 let mut __positional_index = 0;
                 'parse_args: while let Some(&__next_arg) = __remaining_args.get(0) {
                     __remaining_args = &__remaining_args[1..];
-                    if __next_arg == "--help" || __next_arg == "help" {
+                    if !#disable_help && __next_arg == "--help" || __next_arg == "help" {
                         __help = true;
                         continue;
                     }

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -304,7 +304,7 @@ fn impl_from_args_struct(
 
     // Identifier referring to a value containing the name of the current command as an `&[&str]`.
     let cmd_name_str_array_ident = syn::Ident::new("__cmd_name", impl_span.clone());
-    let help = help::help(errors, cmd_name_str_array_ident, type_attrs, &fields, subcommand);
+    let help_impl = help::help(errors, name, type_attrs, &fields, subcommand);
 
     let trait_impl = quote_spanned! { impl_span =>
         impl argh::FromArgs for #name {
@@ -377,8 +377,9 @@ fn impl_from_args_struct(
                 }
 
                 if __help {
+					let __help_message = <Self as ::argh::HelpMessage>::help_message(#cmd_name_str_array_ident);
                     return std::result::Result::Err(argh::EarlyExit {
-                        output: #help,
+                        output: __help_message,
                         status: std::result::Result::Ok(()),
                     });
                 }
@@ -396,7 +397,8 @@ fn impl_from_args_struct(
         }
 
         #top_or_sub_cmd_impl
-    };
+		#help_impl
+	};
 
     trait_impl.into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,17 @@ impl<T: SubCommand> SubCommands for T {
     const COMMANDS: &'static [&'static CommandInfo] = &[T::COMMAND];
 }
 
+/// A `HelpMessage` implementation that provides a help/usage message corresponding
+/// to the type's `FromArgs` implementation.
+pub trait HelpMessage: FromArgs {
+    /// The help/usage message.
+    ///
+    /// The first argument `command_name` is the identifier for the current
+    /// command, treating each segment as space-separated. This will be used
+    /// in the help message.
+    fn help_message(command_name: &[&str]) -> String;
+}
+
 /// Information to display to the user about why a `FromArgs` construction exited early.
 ///
 /// This can occur due to either failed parsing or a flag like `--help`.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -317,13 +317,7 @@ Options:
 
     #[test]
     fn mixed_with_option() {
-        assert_output(
-            &["first", "--b", "foo"],
-            WithOption {
-                a: "first".into(),
-                b: "foo".into(),
-            },
-        );
+        assert_output(&["first", "--b", "foo"], WithOption { a: "first".into(), b: "foo".into() });
 
         assert_error::<WithOption>(
             &[],


### PR DESCRIPTION
This pull request introduces a `HelpMessage` trait that is implemented for every struct that derives `FromArgs`, allowing the user to manually display the help message generated by `argh`. Also, the user can specify `#[argh(disable_help = true)]` which disables the built-in help flag and allows the user to add custom help flags, allowing for shorthands like `-h` or `-?` and similar customizations. Closes #30 