### PR TITLE
Manually print usage

### DIFF
--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -15,13 +15,14 @@ use {
 
 const SECTION_SEPARATOR: &str = "\n\n";
 
+
 /// Returns a `TokenStream` generating a `String` help message.
 ///
 /// Note: `fields` entries with `is_subcommand.is_some()` will be ignored
 /// in favor of the `subcommand` argument.
 pub(crate) fn help(
     errors: &Errors,
-    cmd_name_str_array_ident: syn::Ident,
+    cmd_name_str_array_ident: &syn::Ident,
     ty_attrs: &TypeAttrs,
     fields: &[StructField<'_>],
     subcommand: Option<&StructField<'_>>,
@@ -102,6 +103,24 @@ pub(crate) fn help(
         #subcommand_calculation
         format!(#format_lit, command_name = #cmd_name_str_array_ident.join(" "), #subcommand_format_arg)
     } }
+}
+
+/// Returns a `TokenStream` of the `print_usage` method implementation
+/// The `print_usage` method allows to manually print usage
+pub(crate) fn print_usage(
+    name: &syn::Ident,
+    help: &TokenStream
+) -> TokenStream {
+    quote! {
+        impl #name {
+            fn print_usage(self: &Self) -> String {
+                let strings: Vec<String> = std::env::args().collect();
+                let strs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
+                let __cmd_name = &[strs[0]];
+                #help.to_string()
+            }
+        }
+    }
 }
 
 /// A section composed of exactly just the literals provided to the program.

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -52,6 +52,7 @@ fn impl_from_args(input: &syn::DeriveInput) -> TokenStream {
         }
     };
     errors.to_tokens(&mut output_tokens);
+    
     output_tokens
 }
 
@@ -304,7 +305,10 @@ fn impl_from_args_struct(
 
     // Identifier referring to a value containing the name of the current command as an `&[&str]`.
     let cmd_name_str_array_ident = syn::Ident::new("__cmd_name", impl_span.clone());
-    let help = help::help(errors, cmd_name_str_array_ident, type_attrs, &fields, subcommand);
+    let help = help::help(errors, &cmd_name_str_array_ident, type_attrs, &fields, subcommand);
+
+    // Get `TokenStream` of `print_usage` implementation
+    let print_usage = help::print_usage(name, &help);
 
     let trait_impl = quote_spanned! { impl_span =>
         impl argh::FromArgs for #name {
@@ -396,6 +400,8 @@ fn impl_from_args_struct(
         }
 
         #top_or_sub_cmd_impl
+
+        #print_usage
     };
 
     trait_impl.into()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -206,6 +206,33 @@ fn assert_error<T: FromArgs + Debug>(args: &[&str], err_msg: &str) {
     e.status.expect_err("error had a positive status");
 }
 
+#[test]
+fn print_usage() {
+    #[derive(FromArgs, PartialEq, Debug)]
+    /// Reach new heights.
+    struct GoUp {
+        /// whether or not to jump
+        #[argh(switch, short = 'j')]
+        jump: bool,
+
+        /// how high to go
+        #[argh(option)]
+        height: usize,
+
+        /// an optional nickname for the pilot
+        #[argh(option)]
+        pilot_nickname: Option<String>,
+    }
+
+    let up = GoUp::from_args(&["cmdname"], &["-j", "--height", "5"]).expect("failed go_up");
+
+    let usage_is = up.print_usage();
+
+    let usage_should_be = "Usage: ".to_owned() + &std::env::current_exe().unwrap().into_os_string().into_string().unwrap() + &" [-j] --height <height> [--pilot-nickname <pilot-nickname>]\n\nReach new heights.\n\nOptions:\n  -j, --jump        whether or not to jump\n  --height          how high to go\n  --pilot-nickname  an optional nickname for the pilot\n  --help            display usage information\n".to_owned();
+
+    assert_eq!(usage_is, usage_should_be);
+}
+
 mod positional {
     use super::*;
 
@@ -317,13 +344,7 @@ Options:
 
     #[test]
     fn mixed_with_option() {
-        assert_output(
-            &["first", "--b", "foo"],
-            WithOption {
-                a: "first".into(),
-                b: "foo".into(),
-            },
-        );
+        assert_output(&["first", "--b", "foo"], WithOption { a: "first".into(), b: "foo".into() });
 
         assert_error::<WithOption>(
             &[],


### PR DESCRIPTION
This PR adds a `print_usage()` method to the `FromArgs` type, and returns a `String` of the usage.

It is covered by the test `fn print_usage()` in `tests/lib.rs`.

PR also fixes the code formatting from the previous PR which led the rustfmt check to fail.

This is my first PR so don' t hesitate to provide me with feedback/critics !

