### PR TITLE
Add support for option delimiter "--"

### DIFF
--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -326,6 +326,7 @@ fn impl_from_args_struct(
                 let mut __help = false;
                 let mut __remaining_args = __args;
                 let mut __positional_index = 0;
+                let mut __options_ended = false;
                 'parse_args: while let Some(&__next_arg) = __remaining_args.get(0) {
                     __remaining_args = &__remaining_args[1..];
                     if __next_arg == "--help" || __next_arg == "help" {
@@ -333,7 +334,12 @@ fn impl_from_args_struct(
                         continue;
                     }
 
-                    if __next_arg.starts_with("-") {
+                    if __next_arg.starts_with("-") && !__options_ended {
+                        if __next_arg == "--" {
+                            __options_ended = true;
+                            continue;
+                        }
+
                         if __help {
                             return Err(
                                 "Trailing arguments are not allowed after `help`."

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -507,7 +507,28 @@ mod fuchsia_commandline_tools_rubric {
     /// even when their syntax matches that of options. e.g. `foo -- -e` should be parsed
     /// as passing a single positional argument with the value `-e`.
     #[test]
-    fn double_dash_positional() {}
+    fn double_dash_positional() {
+        #[derive(FromArgs, Debug, PartialEq)]
+        /// Positional arguments list
+        struct StringList {
+            #[argh(positional)]
+            /// a list of strings
+            strs: Vec<String>,
+
+            #[argh(switch)]
+            /// some flag
+            flag: bool,
+        }
+
+        assert_output(
+            &["--", "a", "-b", "--flag"],
+            StringList { strs: vec!["a".into(), "-b".into(), "--flag".into()], flag: false },
+        );
+        assert_output(
+            &["--flag", "--", "-a", "b"],
+            StringList { strs: vec!["-a".into(), "b".into()], flag: true },
+        );
+    }
 
     /// Double-dash can be parsed into an optional field using a provided
     /// `fn(&[&str]) -> Result<T, EarlyExit>`.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -317,13 +317,7 @@ Options:
 
     #[test]
     fn mixed_with_option() {
-        assert_output(
-            &["first", "--b", "foo"],
-            WithOption {
-                a: "first".into(),
-                b: "foo".into(),
-            },
-        );
+        assert_output(&["first", "--b", "foo"], WithOption { a: "first".into(), b: "foo".into() });
 
         assert_error::<WithOption>(
             &[],


### PR DESCRIPTION
Following the Fuchsia CLI Tool Rubric
(https://fuchsia.dev/fuchsia-src/concepts/api/cli#option_delimiter),
this adds support for "--", which denotes the end of the options list.
All arguments that come after this point will be treated as positional,
even if they begin with "-".

Closes #58. Closes #59.