### PR TITLE
Fix quoting in errors when parsing arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,7 +445,8 @@ pub fn parse_positional(
 ) -> Result<(), String> {
     let (slot, name) = positional;
     slot.fill_slot(arg).map_err(|s| {
-        ["Error parsing positional argument '", name, "' with value '", arg, ": ", &s].concat()
+        ["Error parsing positional argument '", name, "' with value '", arg, "': ", &s, "\n"]
+            .concat()
     })
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -206,6 +206,28 @@ fn assert_error<T: FromArgs + Debug>(args: &[&str], err_msg: &str) {
     e.status.expect_err("error had a positive status");
 }
 
+mod options {
+    use super::*;
+
+    #[derive(argh::FromArgs, Debug, PartialEq)]
+    /// Woot
+    struct Parsed {
+        #[argh(option, short = 'n')]
+        /// fooey
+        n: usize,
+    }
+
+    #[test]
+    fn parsed() {
+        assert_output(&["-n", "5"], Parsed { n: 5 });
+        assert_error::<Parsed>(
+            &["-n", "x"],
+            r###"Error parsing option '-n' with value 'x': invalid digit found in string
+"###,
+        );
+    }
+}
+
 mod positional {
     use super::*;
 
@@ -300,6 +322,24 @@ Options:
             &["5"],
             r###"Required positional arguments not provided:
     b
+"###,
+        );
+    }
+
+    #[derive(argh::FromArgs, Debug, PartialEq)]
+    /// Woot
+    struct Parsed {
+        #[argh(positional)]
+        /// fooey
+        n: usize,
+    }
+
+    #[test]
+    fn parsed() {
+        assert_output(&["5"], Parsed { n: 5 });
+        assert_error::<Parsed>(
+            &["x"],
+            r###"Error parsing positional argument 'n' with value 'x': invalid digit found in string
 "###,
         );
     }


### PR DESCRIPTION
This closes quotes in error messages when parsing arguments.

Test: Added tests to make sure the error message when parsing arguments is as expected, as well as added a test to check parsing options.

Closes #52