### PR TITLE
Remove letter-case restriction for attribute descriptions

### DIFF
--- a/argh_derive/src/parse_attrs.rs
+++ b/argh_derive/src/parse_attrs.rs
@@ -139,10 +139,6 @@ impl FieldAttrs {
             }
         }
 
-        if let Some(d) = &this.description {
-            check_option_description(errors, d.content.value().trim(), d.content.span());
-        }
-
         this
     }
 
@@ -408,19 +404,6 @@ impl TypeAttrs {
             errors.duplicate_attrs("subcommand", first, ident);
         } else {
             self.is_subcommand = Some(ident.clone());
-        }
-    }
-}
-
-fn check_option_description(errors: &Errors, desc: &str, span: Span) {
-    let chars = &mut desc.trim().chars();
-    match (chars.next(), chars.next()) {
-        (Some(x), _) if x.is_lowercase() => {}
-        // If both the first and second letter are not lowercase,
-        // this is likely an initialism which should be allowed.
-        (Some(x), Some(y)) if !x.is_lowercase() && !y.is_lowercase() => {}
-        _ => {
-            errors.err_span(span, "Descriptions must begin with a lowercase letter");
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -126,16 +126,6 @@ fn explicit_long_value_for_option() {
     assert_eq!(cmd.x, 5);
 }
 
-/// Test that descriptions can start with an initialism despite
-/// usually being required to start with a lowercase letter.
-#[derive(FromArgs)]
-#[allow(unused)]
-struct DescriptionStartsWithInitialism {
-    /// URL fooey
-    #[argh(option)]
-    x: u8,
-}
-
 #[test]
 fn default_number() {
     #[derive(FromArgs)]


### PR DESCRIPTION
Removes the unnecessary restriction for descriptions to start with a lowercase letter. 

Descriptions should not be required to start with a lowercase letter. This is not a standard.

Examples
```
struct Config {
    #[argh(switch)]
    /// Doggos are noisy. Dog goes WOOF
    bark: bool,
}
```
