### PR TITLE
Add support for an `omit_usage` attribute

### DIFF
--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -28,7 +28,8 @@ pub(crate) fn help(
 ) -> TokenStream {
     let mut format_lit = "Usage: {command_name}".to_string();
 
-    let positional = fields.iter().filter(|f| f.kind == FieldKind::Positional);
+    let positional =
+        fields.iter().filter(|f| f.kind == FieldKind::Positional && !f.attrs.omit_usage);
     for arg in positional {
         format_lit.push(' ');
         positional_usage(&mut format_lit, arg);

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-
 /// Implementation of the `FromArgs` and `argh(...)` derive attributes.
 ///
 /// For more thorough documentation, see the `argh` crate itself.

--- a/argh_derive/src/parse_attrs.rs
+++ b/argh_derive/src/parse_attrs.rs
@@ -17,6 +17,7 @@ pub struct FieldAttrs {
     pub field_type: Option<FieldType>,
     pub long: Option<syn::LitStr>,
     pub short: Option<syn::LitChar>,
+    pub omit_usage: bool,
 }
 
 /// The purpose of a particular field on a `#![derive(FromArgs)]` struct.
@@ -115,13 +116,15 @@ impl FieldAttrs {
                         FieldKind::Positional,
                         &mut this.field_type,
                     );
+                } else if name.is_ident("omit_usage") {
+                    this.omit_usage = true;
                 } else {
                     errors.err(
                         &meta,
                         concat!(
                             "Invalid field-level `argh` attribute\n",
                             "Expected one of: `default`, `description`, `from_str_fn`, `long`, ",
-                            "`option`, `short`, `subcommand`, `switch`",
+                            "`option`, `short`, `subcommand`, `switch`, `omit_usage`",
                         ),
                     );
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,26 @@
 //!     fooey: bool,
 //! }
 //! ```
+//!
+//! Programs that are run from an environment such as cargo may find it
+//! useful to have positional arguments present in the structure but
+//! omitted from the usage output. This can be accomplished by adding
+//! the `omit_usage` attribute to that argument:
+//!
+//! ```rust
+//! # use argh::FromArgs;
+//!
+//! #[derive(FromArgs)]
+//! ///
+//! struct CargoArgs {
+//!     // Cargo puts the command name invoked into the first argument,
+//!     // so we don't want this argument to show up in the usage text.
+//!     #[argh(positional, omit_usage)]
+//!     command: String,
+//!     #[argh(positional)]
+//!     real_first_arg: String,
+//! }
+//! ```
 
 #![deny(missing_docs)]
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -864,4 +864,28 @@ Error codes:
 "###,
         );
     }
+
+    #[test]
+    fn omit_usage_attribute() {
+        #[derive(FromArgs)]
+        /// Short description
+        struct Cmd {
+            /// this one should be hidden
+            #[argh(positional, omit_usage)]
+            _one: String,
+            #[argh(positional)]
+            /// this one is real
+            _two: String,
+        }
+
+        assert_help_string::<Cmd>(
+            r###"Usage: test_arg_0 <_two>
+
+Short description
+
+Options:
+  --help            display usage information
+"###,
+        );
+    }
 }


### PR DESCRIPTION
This causes the following positional argument to be omitted from the
usage text, useful for writing commands for environments like cargo.

Signed-off-by: Bruce Guenter <bruce@untroubled.org>

Closes #73