### PR TITLE
added arg_name attribute, repeatable options are now documented

### DIFF
--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -157,7 +157,14 @@ fn option_usage(out: &mut String, field: &StructField<'_>) {
         FieldKind::Switch => {}
         FieldKind::Option => {
             out.push_str(" <");
-            out.push_str(long_name.trim_start_matches("--"));
+            if let Some(arg_name) = &field.attrs.arg_name {
+                out.push_str(&arg_name.value());
+            } else {
+                out.push_str(long_name.trim_start_matches("--"));
+            }
+            if field.optionality == Optionality::Repeating {
+                out.push_str("...");
+            }
             out.push('>');
         }
     }

--- a/argh_derive/src/parse_attrs.rs
+++ b/argh_derive/src/parse_attrs.rs
@@ -17,6 +17,7 @@ pub struct FieldAttrs {
     pub field_type: Option<FieldType>,
     pub long: Option<syn::LitStr>,
     pub short: Option<syn::LitChar>,
+    pub arg_name: Option<syn::LitStr>,
 }
 
 /// The purpose of a particular field on a `#![derive(FromArgs)]` struct.
@@ -77,7 +78,11 @@ impl FieldAttrs {
                 let meta = if let Some(m) = errors.expect_nested_meta(meta) { m } else { continue };
 
                 let name = meta.path();
-                if name.is_ident("default") {
+                if name.is_ident("arg_name") {
+                    if let Some(m) = errors.expect_meta_name_value(&meta) {
+                        this.parse_attr_arg_name(errors, m);
+                    }
+                } else if name.is_ident("default") {
                     if let Some(m) = errors.expect_meta_name_value(&meta) {
                         this.parse_attr_default(errors, m);
                     }
@@ -120,7 +125,7 @@ impl FieldAttrs {
                         &meta,
                         concat!(
                             "Invalid field-level `argh` attribute\n",
-                            "Expected one of: `default`, `description`, `from_str_fn`, `long`, ",
+                            "Expected one of: `arg_name`, `default`, `description`, `from_str_fn`, `long`, ",
                             "`option`, `short`, `subcommand`, `switch`",
                         ),
                     );
@@ -152,6 +157,10 @@ impl FieldAttrs {
 
     fn parse_attr_default(&mut self, errors: &Errors, m: &syn::MetaNameValue) {
         parse_attr_single_string(errors, m, "default", &mut self.default);
+    }
+
+    fn parse_attr_arg_name(&mut self, errors: &Errors, m: &syn::MetaNameValue) {
+        parse_attr_single_string(errors, m, "arg_name", &mut self.arg_name);
     }
 
     fn parse_attr_long(&mut self, errors: &Errors, m: &syn::MetaNameValue) {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -226,6 +226,50 @@ mod options {
 "###,
         );
     }
+
+    #[derive(argh::FromArgs, Debug, PartialEq)]
+    /// Woot
+    struct Repeating {
+        #[argh(option, short = 'n')]
+        /// fooey
+        n: Vec<String>,
+    }
+
+    #[test]
+    fn repeating() {
+        assert_help_string::<Repeating>(
+            r###"Usage: test_arg_0 [-n <n...>]
+
+Woot
+
+Options:
+  -n, --n           fooey
+  --help            display usage information
+"###,
+        );
+    }
+
+    #[derive(argh::FromArgs, Debug, PartialEq)]
+    /// Woot
+    struct WithArgName {
+        #[argh(option, arg_name = "name")]
+        /// fooey
+        option_name: Option<String>,
+    }
+
+    #[test]
+    fn with_arg_name() {
+        assert_help_string::<WithArgName>(
+            r###"Usage: test_arg_0 [--option-name <name>]
+
+Woot
+
+Options:
+  --option-name     fooey
+  --help            display usage information
+"###,
+        );
+    }
 }
 
 mod positional {


### PR DESCRIPTION
### repeated `#[argh(option]` arguments are now shown in the help header appropriately:
```rs
#[argh(option)]
/// option
opt: Vec<String>,
```
* old output: `[--opt <opt>]`
* new output: `[--opt <opt...>]`

### Option names can now be overridden with the `arg_name = "string"` attribute:
```rs
#[argh(option, arg_name = "opt_arg")]
/// option
opt: String,
```
* produces: `--opt <opt_arg>`

