### PR TITLE
Enable Fuchsia safe command line tool analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,4 +174,9 @@ struct SubCommandTwo {
 }
 ```
 
+It is also possible to retrieve just the names of the arguments and switches 
+passed at runtime, by including the switch `--dump_args_passed` in the args, similarly
+to how `--help` can be passed. This elides any user values passed and creates an 
+output for safely collecting data for analytics.
+
 NOTE: This is not an officially supported Google product.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ struct SubCommandTwo {
 ```
 
 It is also possible to retrieve just the names of the arguments and switches 
-passed at runtime, by including the switch `--dump_args_passed` in the args, similarly
+passed at runtime, by including the switch `--dump-args-passed` in the args, similarly
 to how `--help` can be passed. This elides any user values passed and creates an 
 output for safely collecting data for analytics.
 

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -411,8 +411,6 @@ fn impl_from_args_struct(
                 }
 
                 if __dump_args {
-                    //let escaped_list: [<&str>] = __args_dump.iter().map(|arg| arg.replace(" ", "\\ ")).collect();
-                    //let escaped_args:String = escaped_list.join(" ").to_string();
                     return std::result::Result::Err(argh::EarlyExit {
                         output: __args_dump.join(" ").to_string(),
                         status: std::result::Result::Ok(()),
@@ -429,7 +427,19 @@ fn impl_from_args_struct(
                     #( #unwrap_fields, )*
                 })
             }
+
+            fn to_args(__cmd_name: &[&str], __args: &[&str])
+                -> String
+            {
+                let result = Self::from_args(__cmd_name, &[&["--dump-args-passed"], __args].concat());
+                match result {
+                    Err(e) => e.output,
+                    _ => "Could not produce args list".to_string()
+                }
+            }
+
         }
+
 
         #top_or_sub_cmd_impl
     };
@@ -717,6 +727,11 @@ fn impl_from_args_enum(
                     }
                 )*
                 unreachable!("no subcommand matched")
+            }
+
+            // Note: This can never get called because enums are only SubCommand containers
+            fn to_args(command_name: &[&str], args: &[&str]) -> String {
+                "".to_string()
             }
         }
 

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -292,7 +292,7 @@ fn impl_from_args_struct(
                         __remaining_args
                     };
                     if __dump_args {
-                        __args_dump.push(__subcommand.name.to_string());
+                        __args_dump.push(__subcommand.name.to_string().replace(" ", "\\ "));
                         match <#ty as argh::FromArgs>::from_args(&__command, &[&["--dump-args-passed"], __remaining_args].concat()) {
                             Ok(val) => #name = Some(val),
                             Err(e) => {
@@ -411,6 +411,8 @@ fn impl_from_args_struct(
                 }
 
                 if __dump_args {
+                    //let escaped_list: [<&str>] = __args_dump.iter().map(|arg| arg.replace(" ", "\\ ")).collect();
+                    //let escaped_args:String = escaped_list.join(" ").to_string();
                     return std::result::Result::Err(argh::EarlyExit {
                         output: __args_dump.join(" ").to_string(),
                         status: std::result::Result::Ok(()),

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -293,7 +293,7 @@ fn impl_from_args_struct(
                     };
                     if __dump_args {
                         __args_dump.push(__subcommand.name.to_string());
-                        match <#ty as argh::FromArgs>::from_args(&__command, &[&["--dump_args_passed"], __remaining_args].concat()) {
+                        match <#ty as argh::FromArgs>::from_args(&__command, &[&["--dump-args-passed"], __remaining_args].concat()) {
                             Ok(val) => #name = Some(val),
                             Err(e) => {
                                 __args_dump.push(e.output);
@@ -348,7 +348,7 @@ fn impl_from_args_struct(
                         continue;
                     }
 
-                    if __next_arg == "--dump_args_passed" || __next_arg == "dump_args_passed" {
+                    if __next_arg == "--dump-args-passed" || __next_arg == "dump-args-passed" {
                         __dump_args = true;
                         continue;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,14 +186,6 @@ pub trait FromArgs: Sized {
     /// command, treating each segment as space-separated. This is to be
     /// used in the output of `--help`, `--version`, and similar flags.
     fn from_args(command_name: &[&str], args: &[&str]) -> Result<Self, EarlyExit>;
-
-    // Create a string containing all argument names passed.
-    // This is useful for recording analytics without collecting user values, e.g.
-    // arg_names_passed(["--cc","1234 5555 6565 4321"]) => "cc".
-    //
-    // The first argument `command_name` is the identifier for the current
-    // command, treating each segment as space-separated. This is to be
-    //fn arg_names_passed(command_name: &[&str], args: &[&str]) -> Result<String, EarlyExit>;
 }
 
 /// A top-level `FromArgs` implementation that is not a subcommand.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,13 @@ pub trait FromArgs: Sized {
     /// command, treating each segment as space-separated. This is to be
     /// used in the output of `--help`, `--version`, and similar flags.
     fn from_args(command_name: &[&str], args: &[&str]) -> Result<Self, EarlyExit>;
+
+    /// Get a String with just the arg names, e.g., options, flags, subcommands, etc.
+    ///
+    /// The first argument `command_name` is the identifier for the current
+    /// command, treating each segment as space-separated. The second argument,
+    /// args, is the rest of the command line arguments.
+    fn to_args(command_name: &[&str], args: &[&str]) -> String;
 }
 
 /// A top-level `FromArgs` implementation that is not a subcommand.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1136,3 +1136,45 @@ fn arg_names_passed_subcommand() {
             .expect_err("Should have returned dump of args");
     assert_eq!("speed walking --music", actual.output);
 }
+
+#[test]
+fn arg_names_passed_subcommand_with_space_in_name() {
+    #[derive(FromArgs, Debug)]
+    /// Short description
+    struct Cmd {
+        #[argh(positional)]
+        /// speed of cmd
+        speed: u8,
+
+        #[argh(subcommand)]
+        /// means of transportation
+        means: MeansSubcommand,
+    }
+
+    #[derive(FromArgs, Debug)]
+    /// Short description
+    #[argh(subcommand)]
+    enum MeansSubcommand {
+        Walking(WalkingSubcommand),
+        Biking(BikingSubcommand),
+    }
+
+    #[derive(FromArgs, Debug)]
+    #[argh(subcommand, name = "has space")]
+    /// Short description
+    struct WalkingSubcommand {
+        #[argh(option)]
+        /// a song to listen to
+        music: String,
+    }
+
+    #[derive(FromArgs, Debug)]
+    #[argh(subcommand, name = "biking")]
+    /// Short description
+    struct BikingSubcommand {}
+
+    let actual =
+        Cmd::from_args(&["cmdname"], &["--dump-args-passed", "5", "has space", "--music", "Bach"])
+            .expect_err("Should have returned dump of args");
+    assert_eq!("speed has\\ space --music", actual.output);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,9 +26,8 @@ fn basic_example() {
     let up = GoUp::from_args(&["cmdname"], &["--height", "5"]).expect("failed go_up");
     assert_eq!(up, GoUp { jump: false, height: 5, pilot_nickname: None });
 
-    let actual = GoUp::from_args(&["cmdname"], &["--dump-args-passed", "--height", "5"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("--height", actual.output);
+    let actual = GoUp::to_args(&["cmdname"], &["--height", "5"]);
+    assert_eq!("--height", actual);
 }
 
 #[test]
@@ -48,9 +47,8 @@ fn custom_from_str_example() {
     let f = FiveStruct::from_args(&["cmdname"], &["--five", "woot"]).expect("failed to five");
     assert_eq!(f.five, 5);
 
-    let actual = FiveStruct::from_args(&["cmdname"], &["--dump-args-passed", "--five", "woot"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("--five", actual.output);
+    let actual = FiveStruct::to_args(&["cmdname"], &["--five", "woot"]);
+    assert_eq!("--five", actual);
 }
 
 #[test]
@@ -93,9 +91,8 @@ fn subcommand_example() {
     let two = TopLevel::from_args(&["cmdname"], &["two", "--fooey"]).expect("sc 2");
     assert_eq!(two, TopLevel { nested: MySubCommandEnum::Two(SubCommandTwo { fooey: true }) },);
 
-    let actual = TopLevel::from_args(&["cmdname"], &["--dump-args-passed", "two", "--fooey"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("two --fooey", actual.output);
+    let actual = TopLevel::to_args(&["cmdname"], &["two", "--fooey"]);
+    assert_eq!("two --fooey", actual);
 }
 
 #[test]
@@ -180,9 +177,8 @@ fn default_function() {
     let cmd = Cmd::from_args(&["cmdname"], &[]).unwrap();
     assert_eq!(cmd.msg, MSG);
 
-    let actual = Cmd::from_args(&["cmdname"], &["--dump-args-passed"])
-        .expect_err("Should have returned args passed");
-    assert_eq!("", actual.output);
+    let actual = Cmd::to_args(&["cmdname"], &[]);
+    assert_eq!("", actual);
 }
 
 #[test]
@@ -829,13 +825,11 @@ Options:
             },
         );
 
-        let result = HelpExample::from_args(
+        let result = HelpExample::to_args(
             &["<<<arg0>>>"],
-            &["--dump-args-passed", "-f", "--scribble", "fooey", "blow-up", "--safely"],
-        )
-        .expect_err("Should have returned args passed");
-        assert_eq!(Ok(()), result.status);
-        assert_eq!("-f --scribble blow-up --safely".to_string(), result.output);
+            &["-f", "--scribble", "fooey", "blow-up", "--safely"],
+        );
+        assert_eq!("-f --scribble blow-up --safely".to_string(), result);
     }
 
     #[test]
@@ -901,9 +895,8 @@ fn arg_names_passed_no_args() {
     }
 
     let expected: &str = "";
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed"])
-        .expect_err("Should have returned dump of args passed");
-    assert_eq!(expected, actual.output);
+    let actual = Cmd::to_args(&["unused"], &[]);
+    assert_eq!(expected, actual);
 }
 
 #[test]
@@ -916,9 +909,8 @@ fn arg_names_passed_optional_arg() {
         msg: Option<String>,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "--msg", "hello"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("--msg", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["--msg", "hello"]);
+    assert_eq!("--msg", actual);
 }
 
 #[test]
@@ -935,12 +927,8 @@ fn arg_names_passed_two_option_args() {
         delivery: String,
     }
 
-    let actual = Cmd::from_args(
-        &["unused"],
-        &["--dump-args-passed", "--msg", "hello", "--delivery", "next day"],
-    )
-    .expect_err("Should have returned dump of args");
-    assert_eq!("--msg --delivery", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["--msg", "hello", "--delivery", "next day"]);
+    assert_eq!("--msg --delivery", actual);
 }
 
 #[test]
@@ -957,16 +945,11 @@ fn arg_names_passed_option_one_optional_args() {
         delivery: Option<String>,
     }
 
-    let actual = Cmd::from_args(
-        &["unused"],
-        &["--dump-args-passed", "--msg", "hello", "--delivery", "next day"],
-    )
-    .expect_err("Should have returned dump of args");
-    assert_eq!("--msg --delivery", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["--msg", "hello", "--delivery", "next day"]);
+    assert_eq!("--msg --delivery", actual);
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "--msg", "hello"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("--msg", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["--msg", "hello"]);
+    assert_eq!("--msg", actual);
 }
 
 #[test]
@@ -979,13 +962,11 @@ fn arg_names_passed_switch() {
         faster: bool,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "--faster"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("--faster", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["--faster"]);
+    assert_eq!("--faster", actual);
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "-f"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("-f", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["-f"]);
+    assert_eq!("-f", actual);
 }
 
 #[test]
@@ -998,9 +979,8 @@ fn arg_names_passed_positional() {
         speed: u8,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("speed", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["5"]);
+    assert_eq!("speed", actual);
 }
 
 #[test]
@@ -1013,9 +993,8 @@ fn arg_names_passed_positional_repeating() {
         speed: Vec<u8>,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5", "6"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("speed speed", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["5", "6"]);
+    assert_eq!("speed speed", actual);
 }
 
 #[test]
@@ -1028,9 +1007,8 @@ fn arg_names_passed_positional_err() {
         speed: u8,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("", actual.output);
+    let actual = Cmd::to_args(&["unused"], &[]);
+    assert_eq!("", actual);
 }
 
 #[test]
@@ -1047,9 +1025,8 @@ fn arg_names_passed_two_positional() {
         direction: String,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5", "north"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("speed direction", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["5", "north"]);
+    assert_eq!("speed direction", actual);
 }
 
 #[test]
@@ -1066,9 +1043,8 @@ fn arg_names_passed_positional_option() {
         direction: String,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5", "--direction", "north"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("speed --direction", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["5", "--direction", "north"]);
+    assert_eq!("speed --direction", actual);
 }
 
 #[test]
@@ -1085,9 +1061,8 @@ fn arg_names_passed_positional_optional_option() {
         direction: Option<String>,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5"])
-        .expect_err("Should have returned dump of args");
-    assert_eq!("speed", actual.output);
+    let actual = Cmd::to_args(&["unused"], &["5"]);
+    assert_eq!("speed", actual);
 }
 
 #[test]
@@ -1131,10 +1106,8 @@ fn arg_names_passed_subcommand() {
     /// short description
     struct DrivingSubcommand {}
 
-    let actual =
-        Cmd::from_args(&["cmdname"], &["--dump-args-passed", "5", "walking", "--music", "Bach"])
-            .expect_err("Should have returned dump of args");
-    assert_eq!("speed walking --music", actual.output);
+    let actual = Cmd::to_args(&["cmdname"], &["5", "walking", "--music", "Bach"]);
+    assert_eq!("speed walking --music", actual);
 }
 
 #[test]
@@ -1173,8 +1146,6 @@ fn arg_names_passed_subcommand_with_space_in_name() {
     /// Short description
     struct BikingSubcommand {}
 
-    let actual =
-        Cmd::from_args(&["cmdname"], &["--dump-args-passed", "5", "has space", "--music", "Bach"])
-            .expect_err("Should have returned dump of args");
-    assert_eq!("speed has\\ space --music", actual.output);
+    let to_arg_output = Cmd::to_args(&["cmdname"], &["5", "has space", "--music", "Bach"]);
+    assert_eq!("speed has\\ space --music", to_arg_output);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,7 +26,7 @@ fn basic_example() {
     let up = GoUp::from_args(&["cmdname"], &["--height", "5"]).expect("failed go_up");
     assert_eq!(up, GoUp { jump: false, height: 5, pilot_nickname: None });
 
-    let actual = GoUp::from_args(&["cmdname"], &["--dump_args_passed", "--height", "5"])
+    let actual = GoUp::from_args(&["cmdname"], &["--dump-args-passed", "--height", "5"])
         .expect_err("Should have returned dump of args");
     assert_eq!("--height", actual.output);
 }
@@ -48,7 +48,7 @@ fn custom_from_str_example() {
     let f = FiveStruct::from_args(&["cmdname"], &["--five", "woot"]).expect("failed to five");
     assert_eq!(f.five, 5);
 
-    let actual = FiveStruct::from_args(&["cmdname"], &["--dump_args_passed", "--five", "woot"])
+    let actual = FiveStruct::from_args(&["cmdname"], &["--dump-args-passed", "--five", "woot"])
         .expect_err("Should have returned dump of args");
     assert_eq!("--five", actual.output);
 }
@@ -93,7 +93,7 @@ fn subcommand_example() {
     let two = TopLevel::from_args(&["cmdname"], &["two", "--fooey"]).expect("sc 2");
     assert_eq!(two, TopLevel { nested: MySubCommandEnum::Two(SubCommandTwo { fooey: true }) },);
 
-    let actual = TopLevel::from_args(&["cmdname"], &["--dump_args_passed", "two", "--fooey"])
+    let actual = TopLevel::from_args(&["cmdname"], &["--dump-args-passed", "two", "--fooey"])
         .expect_err("Should have returned dump of args");
     assert_eq!("two --fooey", actual.output);
 }
@@ -180,7 +180,7 @@ fn default_function() {
     let cmd = Cmd::from_args(&["cmdname"], &[]).unwrap();
     assert_eq!(cmd.msg, MSG);
 
-    let actual = Cmd::from_args(&["cmdname"], &["--dump_args_passed"])
+    let actual = Cmd::from_args(&["cmdname"], &["--dump-args-passed"])
         .expect_err("Should have returned args passed");
     assert_eq!("", actual.output);
 }
@@ -831,7 +831,7 @@ Options:
 
         let result = HelpExample::from_args(
             &["<<<arg0>>>"],
-            &["--dump_args_passed", "-f", "--scribble", "fooey", "blow-up", "--safely"],
+            &["--dump-args-passed", "-f", "--scribble", "fooey", "blow-up", "--safely"],
         )
         .expect_err("Should have returned args passed");
         assert_eq!(Ok(()), result.status);
@@ -901,7 +901,7 @@ fn arg_names_passed_no_args() {
     }
 
     let expected: &str = "";
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed"])
         .expect_err("Should have returned dump of args passed");
     assert_eq!(expected, actual.output);
 }
@@ -916,7 +916,7 @@ fn arg_names_passed_optional_arg() {
         msg: Option<String>,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "--msg", "hello"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "--msg", "hello"])
         .expect_err("Should have returned dump of args");
     assert_eq!("--msg", actual.output);
 }
@@ -937,7 +937,7 @@ fn arg_names_passed_two_option_args() {
 
     let actual = Cmd::from_args(
         &["unused"],
-        &["--dump_args_passed", "--msg", "hello", "--delivery", "next day"],
+        &["--dump-args-passed", "--msg", "hello", "--delivery", "next day"],
     )
     .expect_err("Should have returned dump of args");
     assert_eq!("--msg --delivery", actual.output);
@@ -959,12 +959,12 @@ fn arg_names_passed_option_one_optional_args() {
 
     let actual = Cmd::from_args(
         &["unused"],
-        &["--dump_args_passed", "--msg", "hello", "--delivery", "next day"],
+        &["--dump-args-passed", "--msg", "hello", "--delivery", "next day"],
     )
     .expect_err("Should have returned dump of args");
     assert_eq!("--msg --delivery", actual.output);
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "--msg", "hello"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "--msg", "hello"])
         .expect_err("Should have returned dump of args");
     assert_eq!("--msg", actual.output);
 }
@@ -979,11 +979,11 @@ fn arg_names_passed_switch() {
         faster: bool,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "--faster"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "--faster"])
         .expect_err("Should have returned dump of args");
     assert_eq!("--faster", actual.output);
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "-f"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "-f"])
         .expect_err("Should have returned dump of args");
     assert_eq!("-f", actual.output);
 }
@@ -998,7 +998,7 @@ fn arg_names_passed_positional() {
         speed: u8,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "5"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5"])
         .expect_err("Should have returned dump of args");
     assert_eq!("speed", actual.output);
 }
@@ -1013,7 +1013,7 @@ fn arg_names_passed_positional_repeating() {
         speed: Vec<u8>,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "5", "6"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5", "6"])
         .expect_err("Should have returned dump of args");
     assert_eq!("speed speed", actual.output);
 }
@@ -1028,7 +1028,7 @@ fn arg_names_passed_positional_err() {
         speed: u8,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed"])
         .expect_err("Should have returned dump of args");
     assert_eq!("", actual.output);
 }
@@ -1047,7 +1047,7 @@ fn arg_names_passed_two_positional() {
         direction: String,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "5", "north"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5", "north"])
         .expect_err("Should have returned dump of args");
     assert_eq!("speed direction", actual.output);
 }
@@ -1066,7 +1066,7 @@ fn arg_names_passed_positional_option() {
         direction: String,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "5", "--direction", "north"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5", "--direction", "north"])
         .expect_err("Should have returned dump of args");
     assert_eq!("speed --direction", actual.output);
 }
@@ -1085,7 +1085,7 @@ fn arg_names_passed_positional_optional_option() {
         direction: Option<String>,
     }
 
-    let actual = Cmd::from_args(&["unused"], &["--dump_args_passed", "5"])
+    let actual = Cmd::from_args(&["unused"], &["--dump-args-passed", "5"])
         .expect_err("Should have returned dump of args");
     assert_eq!("speed", actual.output);
 }
@@ -1132,7 +1132,7 @@ fn arg_names_passed_subcommand() {
     struct DrivingSubcommand {}
 
     let actual =
-        Cmd::from_args(&["cmdname"], &["--dump_args_passed", "5", "walking", "--music", "Bach"])
+        Cmd::from_args(&["cmdname"], &["--dump-args-passed", "5", "walking", "--music", "Bach"])
             .expect_err("Should have returned dump of args");
     assert_eq!("speed walking --music", actual.output);
 }


### PR DESCRIPTION
This PR allows Fuchsia DX tools to collect analytics without collecting any user passed data. 

Any tool that wants to collect analytics can re-parse the args with an extra flag, "--dump_args_passed" to retrieve a string of the command options suitable for posting to analytics.