### PR TITLE
Don't process '--help' after option delimiter '--'

### DIFF
--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -329,7 +329,7 @@ fn impl_from_args_struct(
                 let mut __options_ended = false;
                 'parse_args: while let Some(&__next_arg) = __remaining_args.get(0) {
                     __remaining_args = &__remaining_args[1..];
-                    if __next_arg == "--help" || __next_arg == "help" {
+                    if (__next_arg == "--help" || __next_arg == "help") && !__options_ended {
                         __help = true;
                         continue;
                     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -568,6 +568,11 @@ mod fuchsia_commandline_tools_rubric {
             &["--flag", "--", "-a", "b"],
             StringList { strs: vec!["-a".into(), "b".into()], flag: true },
         );
+        assert_output(&["--", "--help"], StringList { strs: vec!["--help".into()], flag: false });
+        assert_output(
+            &["--", "-a", "--help"],
+            StringList { strs: vec!["-a".into(), "--help".into()], flag: false },
+        );
     }
 
     /// Double-dash can be parsed into an optional field using a provided


### PR DESCRIPTION
The option `--` acts as an "option delimiter" -- all arguments
which come after that point are treated as position arguments,
even if they begin with `-`. This functionality was added in #60.

However, there was a slight issue. Because the `--help` flag is
parsed separately from the rest of the arguments, `--help` would
trigger the early-exit help message, even after `--`.