### PR TITLE
Remove stubs for verbose/quiet/version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,14 +391,6 @@ pub fn unrecognized_argument(x: &str) -> String {
     ["Unrecognized argument: ", x, "\n"].concat()
 }
 
-// A sentinel value that indicates that there is no
-// output table mapping for the given flag.
-// This is used for arguments like `--verbose` and `--quiet`
-// that must be silently accepted if the `argh` user hasn't
-// specified their behavior explicitly.
-#[doc(hidden)]
-pub const OUTPUT_TABLE_NONE: usize = std::usize::MAX;
-
 /// Parse a commandline option.
 ///
 /// `arg`: the current option argument being parsed (e.g. `--foo`).
@@ -420,10 +412,6 @@ pub fn parse_option(
         .iter()
         .find_map(|&(name, pos)| if name == arg { Some(pos) } else { None })
         .ok_or_else(|| unrecognized_argument(arg))?;
-
-    if pos == OUTPUT_TABLE_NONE {
-        return Ok(());
-    }
 
     match &mut output_table[pos] {
         CmdOption::Flag(b) => b.set_flag(),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -752,44 +752,6 @@ Options:
         e.status.expect_err("should be an error");
     }
 
-    // Commandline tools are expected to support common switches:
-    // --help
-    // --quiet
-    // --verbose
-    // --version
-
-    // help_is_supported (see above help_* tests)
-
-    #[test]
-    fn quiet_is_supported() {
-        // TODO support quiet
-    }
-
-    #[test]
-    fn verbose_is_supported() {
-        // TODO support verbose
-    }
-
-    #[test]
-    fn version_is_supported() {
-        // TODO support version
-    }
-
-    #[test]
-    fn quiet_is_not_supported_in_subcommands() {
-        // TODO support quiet
-    }
-
-    #[test]
-    fn verbose_is_not_supported_in_subcommands() {
-        // TODO support verbose
-    }
-
-    #[test]
-    fn version_is_not_supported_in_subcommands() {
-        // TODO support version
-    }
-
     #[derive(FromArgs, PartialEq, Debug)]
     #[argh(
         description = "Destroy the contents of <file>.",


### PR DESCRIPTION
We never ended up implementing `--quiet`, `--verbose`, and `--version`, so we don't need these test stubs.