### PR TITLE
Add support for redacting commandline arguments

### DIFF
--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -378,8 +378,8 @@ fn impl_from_args_struct_redact_arg_values<'a>(
     type_attrs: &TypeAttrs,
     fields: &'a [StructField<'a>],
 ) -> TokenStream {
-    let init_fields = declare_local_storage_for_redact_arg_values_fields(&fields);
-    let unwrap_fields = unwrap_redact_arg_values_fields(&fields);
+    let init_fields = declare_local_storage_for_redacted_fields(&fields);
+    let unwrap_fields = unwrap_redacted_fields(&fields);
 
     let positional_fields: Vec<&StructField<'_>> =
         fields.iter().filter(|field| field.kind == FieldKind::Positional).collect();
@@ -613,7 +613,7 @@ fn unwrap_from_args_fields<'a>(fields: &'a [StructField<'a>]) -> impl Iterator<I
 /// Most fields are stored in `Option<FieldType>` locals.
 /// `argh(option)` fields are stored in a `ParseValueSlotTy` along with a
 /// function that knows how to decode the appropriate value.
-fn declare_local_storage_for_redact_arg_values_fields<'a>(
+fn declare_local_storage_for_redacted_fields<'a>(
     fields: &'a [StructField<'a>],
 ) -> impl Iterator<Item = TokenStream> + 'a {
     fields.iter().map(|field| {
@@ -664,7 +664,7 @@ fn declare_local_storage_for_redact_arg_values_fields<'a>(
 }
 
 /// Unwrap non-optional fields and take options out of their tuple slots.
-fn unwrap_redact_arg_values_fields<'a>(fields: &'a [StructField<'a>]) -> impl Iterator<Item = TokenStream> + 'a {
+fn unwrap_redacted_fields<'a>(fields: &'a [StructField<'a>]) -> impl Iterator<Item = TokenStream> + 'a {
     fields.iter().map(|field| {
         let field_name = field.name;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,15 @@ pub trait FromArgs: Sized {
     /// command, treating each segment as space-separated. This is to be
     /// used in the output of `--help`, `--version`, and similar flags.
     fn from_args(command_name: &[&str], args: &[&str]) -> Result<Self, EarlyExit>;
+
+    /// Get a String with just the argument names, e.g., options, flags, subcommands, etc.
+    ///
+    /// The first argument `command_name` is the identifier for the current
+    /// command, treating each segment as space-separated. The second argument,
+    /// args, is the rest of the command line arguments.
+    fn redact(_command_name: &[&str], _args: &[&str]) -> Result<Vec<String>, EarlyExit> {
+        Ok(vec!["<<REDACTED>>".into()])
+    }
 }
 
 /// A top-level `FromArgs` implementation that is not a subcommand.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ pub trait FromArgs: Sized {
     ///     students: Vec<String>,
     /// }
     ///
-    /// let args = ClassroomCmd::redact(
+    /// let args = ClassroomCmd::redact_arg_values(
     ///         &["classroom"],
     ///         &["list"],
     /// ).unwrap();
@@ -259,7 +259,7 @@ pub trait FromArgs: Sized {
     ///     ],
     /// );
     ///
-    /// let args = ClassroomCmd::redact(
+    /// let args = ClassroomCmd::redact_arg_values(
     ///     &["classroom"],
     ///     &["list", "--teacher-name", "Smith"],
     /// ).unwrap();
@@ -272,7 +272,7 @@ pub trait FromArgs: Sized {
     ///     ],
     /// );
     ///
-    /// let args = ClassroomCmd::redact(
+    /// let args = ClassroomCmd::redact_arg_values(
     ///     &["classroom"],
     ///     &["add", "--teacher-name", "Smith", "--started", "Math", "Abe", "Sung"],
     /// ).unwrap();
@@ -289,16 +289,16 @@ pub trait FromArgs: Sized {
     ///     ],
     /// );
     ///
-    /// // `ClassroomCmd::redact` will error out if passed invalid arguments.
+    /// // `ClassroomCmd::redact_arg_values` will error out if passed invalid arguments.
     /// assert_eq!(
-    ///     ClassroomCmd::redact(&["classroom"], &["add", "--teacher-name"]),
+    ///     ClassroomCmd::redact_arg_values(&["classroom"], &["add", "--teacher-name"]),
     ///     Err(argh::EarlyExit {
     ///         output: "No value provided for option '--teacher-name'.\n".into(),
     ///         status: Err(()),
     ///     }),
     /// );
     /// ```
-    fn redact(_command_name: &[&str], _args: &[&str]) -> Result<Vec<String>, EarlyExit> {
+    fn redact_arg_values(_command_name: &[&str], _args: &[&str]) -> Result<Vec<String>, EarlyExit> {
         Ok(vec!["<<REDACTED>>".into()])
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -960,7 +960,7 @@ fn redact_switch() {
     assert_eq!(actual, &["<<<arg0>>>", "--faster"]);
 
     let actual = Cmd::redact(&["<<<arg0>>>"], &["-f"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "--faster"]);
+    assert_eq!(actual, &["<<<arg0>>>", "-f"]);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -920,7 +920,8 @@ fn redact_arg_values_two_option_args() {
     }
 
     let actual =
-        Cmd::redact_arg_values(&["program-name"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
+        Cmd::redact_arg_values(&["program-name"], &["--msg", "hello", "--delivery", "next day"])
+            .unwrap();
     assert_eq!(actual, &["program-name", "--msg", "--delivery"]);
 }
 
@@ -939,7 +940,8 @@ fn redact_arg_values_option_one_optional_args() {
     }
 
     let actual =
-        Cmd::redact_arg_values(&["program-name"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
+        Cmd::redact_arg_values(&["program-name"], &["--msg", "hello", "--delivery", "next day"])
+            .unwrap();
     assert_eq!(actual, &["program-name", "--msg", "--delivery"]);
 
     let actual = Cmd::redact_arg_values(&["program-name"], &["--msg", "hello"]).unwrap();
@@ -1106,7 +1108,8 @@ fn redact_arg_values_subcommand() {
     /// short description
     struct DrivingSubcommand {}
 
-    let actual = Cmd::redact_arg_values(&["program-name"], &["5", "walking", "--music", "Bach"]).unwrap();
+    let actual =
+        Cmd::redact_arg_values(&["program-name"], &["5", "walking", "--music", "Bach"]).unwrap();
     assert_eq!(actual, &["program-name", "speed", "walking", "--music"]);
 }
 
@@ -1146,7 +1149,8 @@ fn redact_arg_values_subcommand_with_space_in_name() {
     /// Short description
     struct BikingSubcommand {}
 
-    let actual = Cmd::redact_arg_values(&["program-name"], &["5", "has space", "--music", "Bach"]).unwrap();
+    let actual =
+        Cmd::redact_arg_values(&["program-name"], &["5", "has space", "--music", "Bach"]).unwrap();
     assert_eq!(actual, &["program-name", "speed", "has space", "--music"]);
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -808,7 +808,7 @@ Options:
     #[test]
     fn example_parses_correctly() {
         let help_example = HelpExample::from_args(
-            &["<<<arg0>>>"],
+            &["program-name"],
             &["-f", "--scribble", "fooey", "blow-up", "--safely"],
         )
         .unwrap();
@@ -827,7 +827,7 @@ Options:
 
     #[test]
     fn example_errors_on_missing_required_option_and_missing_required_subcommand() {
-        let exit = HelpExample::from_args(&["<<<arg0>>>"], &[]).unwrap_err();
+        let exit = HelpExample::from_args(&["program-name"], &[]).unwrap_err();
         exit.status.unwrap_err();
         assert_eq!(
             exit.output,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -887,8 +887,8 @@ fn redact_no_args() {
         msg: Option<String>,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &[]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>"]);
+    let actual = Cmd::redact(&["program-name"], &[]).unwrap();
+    assert_eq!(actual, &["program-name"]);
 }
 
 #[test]
@@ -901,8 +901,8 @@ fn redact_optional_arg() {
         msg: Option<String>,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["--msg", "hello"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "--msg"]);
+    let actual = Cmd::redact(&["program-name"], &["--msg", "hello"]).unwrap();
+    assert_eq!(actual, &["program-name", "--msg"]);
 }
 
 #[test]
@@ -920,8 +920,8 @@ fn redact_two_option_args() {
     }
 
     let actual =
-        Cmd::redact(&["<<<arg0>>>"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "--msg", "--delivery"]);
+        Cmd::redact(&["program-name"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
+    assert_eq!(actual, &["program-name", "--msg", "--delivery"]);
 }
 
 #[test]
@@ -939,11 +939,11 @@ fn redact_option_one_optional_args() {
     }
 
     let actual =
-        Cmd::redact(&["<<<arg0>>>"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "--msg", "--delivery"]);
+        Cmd::redact(&["program-name"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
+    assert_eq!(actual, &["program-name", "--msg", "--delivery"]);
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["--msg", "hello"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "--msg"]);
+    let actual = Cmd::redact(&["program-name"], &["--msg", "hello"]).unwrap();
+    assert_eq!(actual, &["program-name", "--msg"]);
 }
 
 #[test]
@@ -956,11 +956,11 @@ fn redact_switch() {
         faster: bool,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["--faster"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "--faster"]);
+    let actual = Cmd::redact(&["program-name"], &["--faster"]).unwrap();
+    assert_eq!(actual, &["program-name", "--faster"]);
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["-f"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "-f"]);
+    let actual = Cmd::redact(&["program-name"], &["-f"]).unwrap();
+    assert_eq!(actual, &["program-name", "-f"]);
 }
 
 #[test]
@@ -973,8 +973,8 @@ fn redact_positional() {
         speed: u8,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["5"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "speed"]);
+    let actual = Cmd::redact(&["program-name"], &["5"]).unwrap();
+    assert_eq!(actual, &["program-name", "speed"]);
 }
 
 #[test]
@@ -987,8 +987,8 @@ fn redact_positional_repeating() {
         speed: Vec<u8>,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["5", "6"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "speed", "speed"]);
+    let actual = Cmd::redact(&["program-name"], &["5", "6"]).unwrap();
+    assert_eq!(actual, &["program-name", "speed", "speed"]);
 }
 
 #[test]
@@ -1001,7 +1001,7 @@ fn redact_positional_err() {
         speed: u8,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &[]).unwrap_err();
+    let actual = Cmd::redact(&["program-name"], &[]).unwrap_err();
     assert_eq!(
         actual,
         argh::EarlyExit {
@@ -1025,8 +1025,8 @@ fn redact_two_positional() {
         direction: String,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["5", "north"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "speed", "direction"]);
+    let actual = Cmd::redact(&["program-name"], &["5", "north"]).unwrap();
+    assert_eq!(actual, &["program-name", "speed", "direction"]);
 }
 
 #[test]
@@ -1043,8 +1043,8 @@ fn redact_positional_option() {
         direction: String,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["5", "--direction", "north"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "speed", "--direction"]);
+    let actual = Cmd::redact(&["program-name"], &["5", "--direction", "north"]).unwrap();
+    assert_eq!(actual, &["program-name", "speed", "--direction"]);
 }
 
 #[test]
@@ -1061,8 +1061,8 @@ fn redact_positional_optional_option() {
         direction: Option<String>,
     }
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["5"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "speed"]);
+    let actual = Cmd::redact(&["program-name"], &["5"]).unwrap();
+    assert_eq!(actual, &["program-name", "speed"]);
 }
 
 #[test]
@@ -1106,8 +1106,8 @@ fn redact_subcommand() {
     /// short description
     struct DrivingSubcommand {}
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["5", "walking", "--music", "Bach"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "speed", "walking", "--music"]);
+    let actual = Cmd::redact(&["program-name"], &["5", "walking", "--music", "Bach"]).unwrap();
+    assert_eq!(actual, &["program-name", "speed", "walking", "--music"]);
 }
 
 #[test]
@@ -1146,8 +1146,8 @@ fn redact_subcommand_with_space_in_name() {
     /// Short description
     struct BikingSubcommand {}
 
-    let actual = Cmd::redact(&["<<<arg0>>>"], &["5", "has space", "--music", "Bach"]).unwrap();
-    assert_eq!(actual, &["<<<arg0>>>", "speed", "has space", "--music"]);
+    let actual = Cmd::redact(&["program-name"], &["5", "has space", "--music", "Bach"]).unwrap();
+    assert_eq!(actual, &["program-name", "speed", "has space", "--music"]);
 }
 
 #[test]
@@ -1160,20 +1160,38 @@ fn redact_produces_help() {
         n: Vec<String>,
     }
 
-    match Repeating::redact(&["test_arg_0"], &["--help"]) {
-        Ok(_) => panic!("help was parsed as args"),
-        Err(e) => {
-            assert_eq!(
-                e.output,
-                r###"Usage: test_arg_0 [-n <n...>]
+    assert_eq!(
+        Repeating::redact(&["program-name"], &["--help"]),
+        Err(argh::EarlyExit {
+            output: r###"Usage: program-name [-n <n...>]
 
 Woot
 
 Options:
   -n, --n           fooey
   --help            display usage information
-"###,
-            );
-        }
+"###
+            .to_string(),
+            status: Ok(()),
+        }),
+    );
+}
+
+#[test]
+fn redact_produces_errors_with_bad_arguments() {
+    #[derive(argh::FromArgs, Debug, PartialEq)]
+    /// Woot
+    struct Cmd {
+        #[argh(option, short = 'n')]
+        /// fooey
+        n: String,
     }
+
+    assert_eq!(
+        Cmd::redact(&["program-name"], &["--n"]),
+        Err(argh::EarlyExit {
+            output: "No value provided for option '--n'.\n".to_string(),
+            status: Err(()),
+        }),
+    );
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -878,7 +878,7 @@ Error codes:
 }
 
 #[test]
-fn redact_no_args() {
+fn redact_arg_values_no_args() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -887,12 +887,12 @@ fn redact_no_args() {
         msg: Option<String>,
     }
 
-    let actual = Cmd::redact(&["program-name"], &[]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &[]).unwrap();
     assert_eq!(actual, &["program-name"]);
 }
 
 #[test]
-fn redact_optional_arg() {
+fn redact_arg_values_optional_arg() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -901,12 +901,12 @@ fn redact_optional_arg() {
         msg: Option<String>,
     }
 
-    let actual = Cmd::redact(&["program-name"], &["--msg", "hello"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["--msg", "hello"]).unwrap();
     assert_eq!(actual, &["program-name", "--msg"]);
 }
 
 #[test]
-fn redact_two_option_args() {
+fn redact_arg_values_two_option_args() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -920,12 +920,12 @@ fn redact_two_option_args() {
     }
 
     let actual =
-        Cmd::redact(&["program-name"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
+        Cmd::redact_arg_values(&["program-name"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
     assert_eq!(actual, &["program-name", "--msg", "--delivery"]);
 }
 
 #[test]
-fn redact_option_one_optional_args() {
+fn redact_arg_values_option_one_optional_args() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -939,15 +939,15 @@ fn redact_option_one_optional_args() {
     }
 
     let actual =
-        Cmd::redact(&["program-name"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
+        Cmd::redact_arg_values(&["program-name"], &["--msg", "hello", "--delivery", "next day"]).unwrap();
     assert_eq!(actual, &["program-name", "--msg", "--delivery"]);
 
-    let actual = Cmd::redact(&["program-name"], &["--msg", "hello"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["--msg", "hello"]).unwrap();
     assert_eq!(actual, &["program-name", "--msg"]);
 }
 
 #[test]
-fn redact_switch() {
+fn redact_arg_values_switch() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -956,15 +956,15 @@ fn redact_switch() {
         faster: bool,
     }
 
-    let actual = Cmd::redact(&["program-name"], &["--faster"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["--faster"]).unwrap();
     assert_eq!(actual, &["program-name", "--faster"]);
 
-    let actual = Cmd::redact(&["program-name"], &["-f"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["-f"]).unwrap();
     assert_eq!(actual, &["program-name", "-f"]);
 }
 
 #[test]
-fn redact_positional() {
+fn redact_arg_values_positional() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -973,12 +973,12 @@ fn redact_positional() {
         speed: u8,
     }
 
-    let actual = Cmd::redact(&["program-name"], &["5"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["5"]).unwrap();
     assert_eq!(actual, &["program-name", "speed"]);
 }
 
 #[test]
-fn redact_positional_repeating() {
+fn redact_arg_values_positional_repeating() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -987,12 +987,12 @@ fn redact_positional_repeating() {
         speed: Vec<u8>,
     }
 
-    let actual = Cmd::redact(&["program-name"], &["5", "6"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["5", "6"]).unwrap();
     assert_eq!(actual, &["program-name", "speed", "speed"]);
 }
 
 #[test]
-fn redact_positional_err() {
+fn redact_arg_values_positional_err() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -1001,7 +1001,7 @@ fn redact_positional_err() {
         speed: u8,
     }
 
-    let actual = Cmd::redact(&["program-name"], &[]).unwrap_err();
+    let actual = Cmd::redact_arg_values(&["program-name"], &[]).unwrap_err();
     assert_eq!(
         actual,
         argh::EarlyExit {
@@ -1012,7 +1012,7 @@ fn redact_positional_err() {
 }
 
 #[test]
-fn redact_two_positional() {
+fn redact_arg_values_two_positional() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -1025,12 +1025,12 @@ fn redact_two_positional() {
         direction: String,
     }
 
-    let actual = Cmd::redact(&["program-name"], &["5", "north"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["5", "north"]).unwrap();
     assert_eq!(actual, &["program-name", "speed", "direction"]);
 }
 
 #[test]
-fn redact_positional_option() {
+fn redact_arg_values_positional_option() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -1043,12 +1043,12 @@ fn redact_positional_option() {
         direction: String,
     }
 
-    let actual = Cmd::redact(&["program-name"], &["5", "--direction", "north"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["5", "--direction", "north"]).unwrap();
     assert_eq!(actual, &["program-name", "speed", "--direction"]);
 }
 
 #[test]
-fn redact_positional_optional_option() {
+fn redact_arg_values_positional_optional_option() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -1061,12 +1061,12 @@ fn redact_positional_optional_option() {
         direction: Option<String>,
     }
 
-    let actual = Cmd::redact(&["program-name"], &["5"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["5"]).unwrap();
     assert_eq!(actual, &["program-name", "speed"]);
 }
 
 #[test]
-fn redact_subcommand() {
+fn redact_arg_values_subcommand() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -1106,12 +1106,12 @@ fn redact_subcommand() {
     /// short description
     struct DrivingSubcommand {}
 
-    let actual = Cmd::redact(&["program-name"], &["5", "walking", "--music", "Bach"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["5", "walking", "--music", "Bach"]).unwrap();
     assert_eq!(actual, &["program-name", "speed", "walking", "--music"]);
 }
 
 #[test]
-fn redact_subcommand_with_space_in_name() {
+fn redact_arg_values_subcommand_with_space_in_name() {
     #[derive(FromArgs, Debug)]
     /// Short description
     struct Cmd {
@@ -1146,12 +1146,12 @@ fn redact_subcommand_with_space_in_name() {
     /// Short description
     struct BikingSubcommand {}
 
-    let actual = Cmd::redact(&["program-name"], &["5", "has space", "--music", "Bach"]).unwrap();
+    let actual = Cmd::redact_arg_values(&["program-name"], &["5", "has space", "--music", "Bach"]).unwrap();
     assert_eq!(actual, &["program-name", "speed", "has space", "--music"]);
 }
 
 #[test]
-fn redact_produces_help() {
+fn redact_arg_values_produces_help() {
     #[derive(argh::FromArgs, Debug, PartialEq)]
     /// Woot
     struct Repeating {
@@ -1161,7 +1161,7 @@ fn redact_produces_help() {
     }
 
     assert_eq!(
-        Repeating::redact(&["program-name"], &["--help"]),
+        Repeating::redact_arg_values(&["program-name"], &["--help"]),
         Err(argh::EarlyExit {
             output: r###"Usage: program-name [-n <n...>]
 
@@ -1178,7 +1178,7 @@ Options:
 }
 
 #[test]
-fn redact_produces_errors_with_bad_arguments() {
+fn redact_arg_values_produces_errors_with_bad_arguments() {
     #[derive(argh::FromArgs, Debug, PartialEq)]
     /// Woot
     struct Cmd {
@@ -1188,7 +1188,7 @@ fn redact_produces_errors_with_bad_arguments() {
     }
 
     assert_eq!(
-        Cmd::redact(&["program-name"], &["--n"]),
+        Cmd::redact_arg_values(&["program-name"], &["--n"]),
         Err(argh::EarlyExit {
             output: "No value provided for option '--n'.\n".to_string(),
             status: Err(()),


### PR DESCRIPTION
This is an alternative to #82, which refactors how CLI parsing occurs so it can be also used to redact command line arguments for safe analytics tracking.