### PR TITLE
Print help for positional arguments

### DIFF
--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -299,6 +299,10 @@ mod positional {
 
 Woot
 
+Positional Arguments:
+  a                 fooey
+  b                 fooey
+
 Options:
   --help            display usage information
 "###,
@@ -890,6 +894,9 @@ Error codes:
             r###"Usage: test_arg_0 <name>
 
 Destroy the contents of <file>.
+
+Positional Arguments:
+  name
 
 Options:
   --help            display usage information

--- a/argh_shared/src/lib.rs
+++ b/argh_shared/src/lib.rs
@@ -23,6 +23,11 @@ pub fn write_description(out: &mut String, cmd: &CommandInfo<'_>) {
     let mut current_line = INDENT.to_string();
     current_line.push_str(cmd.name);
 
+    if cmd.description.is_empty() {
+        new_line(&mut current_line, out);
+        return;
+    }
+
     if !indent_description(&mut current_line) {
         // Start the description on a new line if the flag names already
         // add up to more than DESCRIPTION_INDENT.


### PR DESCRIPTION
Fixes #63

This adds the positional arguments names and descriptions to the help.