### PR TITLE
Adding --help-json to get JSON encoded help message

### DIFF
--- a/argh_derive/src/help_json.rs
+++ b/argh_derive/src/help_json.rs
@@ -1,0 +1,234 @@
+// Copyright (c) 2020 Google LLC All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use {
+    crate::{
+        errors::Errors,
+        help::{
+            build_usage_command_line, require_description, HELP_DESCRIPTION, HELP_FLAG,
+            HELP_JSON_DESCRIPTION, HELP_JSON_FLAG,
+        },
+        parse_attrs::{FieldKind, TypeAttrs},
+        StructField,
+    },
+    proc_macro2::{Span, TokenStream},
+    quote::quote,
+};
+
+struct OptionHelp {
+    short: String,
+    long: String,
+    description: String,
+}
+
+struct PositionalHelp {
+    name: String,
+    description: String,
+}
+struct HelpJSON {
+    usage: String,
+    description: String,
+    positional_args: Vec<PositionalHelp>,
+    options: Vec<OptionHelp>,
+    examples: String,
+    notes: String,
+    error_codes: Vec<PositionalHelp>,
+}
+
+fn option_elements_json(options: &[OptionHelp]) -> String {
+    let mut retval = String::from("");
+    for opt in options {
+        if !retval.is_empty() {
+            retval.push_str(",\n    ");
+        }
+        retval.push_str(&format!(
+            "{{\"short\": \"{}\", \"long\": \"{}\", \"description\": \"{}\"}}",
+            opt.short,
+            opt.long,
+            escape_json(&opt.description)
+        ));
+    }
+    retval
+}
+fn help_elements_json(elements: &[PositionalHelp]) -> String {
+    let mut retval = String::from("");
+    for pos in elements {
+        if !retval.is_empty() {
+            retval.push_str(",\n    ");
+        }
+        retval.push_str(&format!(
+            "{{\"name\": \"{}\", \"description\": \"{}\"}}",
+            pos.name,
+            escape_json(&pos.description)
+        ));
+    }
+    retval
+}
+
+/// Returns a `TokenStream` generating a `String` help message containing JSON.
+///
+/// Note: `fields` entries with `is_subcommand.is_some()` will be ignored
+/// in favor of the `subcommand` argument.
+pub(crate) fn help_json(
+    errors: &Errors,
+    cmd_name_str_array_ident: &syn::Ident,
+    ty_attrs: &TypeAttrs,
+    fields: &[StructField<'_>],
+    subcommand: Option<&StructField<'_>>,
+) -> TokenStream {
+    let mut usage_format_pattern = "{command_name}".to_string();
+    build_usage_command_line(&mut usage_format_pattern, fields, subcommand);
+
+    let mut help_obj = HelpJSON {
+        usage: String::from(""),
+        description: String::from(""),
+        positional_args: vec![],
+        options: vec![],
+        examples: String::from(""),
+        notes: String::from(""),
+        error_codes: vec![],
+    };
+
+    // Add positional args to the help object.
+    let positional = fields.iter().filter(|f| f.kind == FieldKind::Positional);
+    for arg in positional {
+        let mut description = String::from("");
+        if let Some(desc) = &arg.attrs.description {
+            description = desc.content.value().trim().to_owned();
+        }
+        help_obj.positional_args.push(PositionalHelp { name: arg.arg_name(), description });
+    }
+
+    // Add options to the help object.
+    let options = fields.iter().filter(|f| f.long_name.is_some());
+    for option in options {
+        let short = match option.attrs.short.as_ref().map(|s| s.value()) {
+            Some(c) => String::from(c),
+            None => String::from(""),
+        };
+        let long_with_leading_dashes =
+            option.long_name.as_ref().expect("missing long name for option");
+        let description =
+            require_description(errors, option.name.span(), &option.attrs.description, "field");
+        help_obj.options.push(OptionHelp {
+            short,
+            long: long_with_leading_dashes.to_owned(),
+            description,
+        });
+    }
+    // Also include "help" and "help-json"
+    help_obj.options.push(OptionHelp {
+        short: String::from(""),
+        long: String::from(HELP_FLAG),
+        description: String::from(HELP_DESCRIPTION),
+    });
+    help_obj.options.push(OptionHelp {
+        short: String::from(""),
+        long: String::from(HELP_JSON_FLAG),
+        description: String::from(HELP_JSON_DESCRIPTION),
+    });
+
+    let subcommand_calculation;
+    if let Some(subcommand) = subcommand {
+        let subcommand_ty = subcommand.ty_without_wrapper;
+        subcommand_calculation = quote! {
+            let mut subcommands = String::from("");
+            for cmd in  <#subcommand_ty as argh::SubCommands>::COMMANDS {
+                if !subcommands.is_empty() {
+                    subcommands.push_str(",\n    ");
+                }
+                subcommands.push_str(&format!("{{\"name\": \"{}\", \"description\": \"{}\"}}",
+            cmd.name, cmd.description));
+            }
+        };
+    } else {
+        subcommand_calculation = quote! {
+            let subcommands = String::from("");
+        };
+    }
+
+    help_obj.usage = usage_format_pattern.clone();
+
+    help_obj.description =
+        require_description(errors, Span::call_site(), &ty_attrs.description, "type");
+
+    let mut example: String = String::from("");
+    for lit in &ty_attrs.examples {
+        example.push_str(&lit.value());
+    }
+    help_obj.examples = example;
+
+    let mut note: String = String::from("");
+    for lit in &ty_attrs.notes {
+        note.push_str(&lit.value());
+    }
+    help_obj.notes = note;
+
+    if !ty_attrs.error_codes.is_empty() {
+        for (code, text) in &ty_attrs.error_codes {
+            help_obj.error_codes.push(PositionalHelp {
+                name: code.to_string(),
+                description: escape_json(&text.value().to_string()),
+            });
+        }
+    }
+
+    let help_options_json = option_elements_json(&help_obj.options);
+    let help_positional_json = help_elements_json(&help_obj.positional_args);
+    let help_error_codes_json = help_elements_json(&help_obj.error_codes);
+
+    let help_description = escape_json(&help_obj.description);
+    let help_examples: TokenStream;
+    let help_notes: TokenStream;
+
+    let notes_pattern = escape_json(&help_obj.notes);
+    // check if we need to interpolate the string.
+    if notes_pattern.contains("{command_name}") {
+        help_notes = quote! {
+            json_help_string.push_str(&format!(#notes_pattern,command_name = #cmd_name_str_array_ident.join(" ")));
+        };
+    } else {
+        help_notes = quote! {
+            json_help_string.push_str(#notes_pattern);
+        };
+    }
+    let examples_pattern = escape_json(&help_obj.examples);
+    if examples_pattern.contains("{command_name}") {
+        help_examples = quote! {
+            json_help_string.push_str(&format!(#examples_pattern,command_name = #cmd_name_str_array_ident.join(" ")));
+        };
+    } else {
+        help_examples = quote! {
+            json_help_string.push_str(#examples_pattern);
+        };
+    }
+
+    quote! {{
+        #subcommand_calculation
+
+        // Build up the string for json. The name of the command needs to be dereferenced, so it
+        // can't be done in the macro.
+        let mut json_help_string = "{\n".to_string();
+        let usage_value = format!(#usage_format_pattern,command_name = #cmd_name_str_array_ident.join(" "));
+        json_help_string.push_str(&format!("\"usage\": \"{}\",\n",usage_value));
+        json_help_string.push_str(&format!("\"description\": \"{}\",\n", #help_description));
+        json_help_string.push_str(&format!("\"options\": [{}],\n", #help_options_json));
+        json_help_string.push_str(&format!("\"positional\": [{}],\n", #help_positional_json));
+        json_help_string.push_str("\"examples\": \"");
+        #help_examples;
+        json_help_string.push_str("\",\n");
+        json_help_string.push_str("\"notes\": \"");
+        #help_notes;
+        json_help_string.push_str("\",\n");
+        json_help_string.push_str(&format!("\"error_codes\": [{}],\n", #help_error_codes_json));
+        json_help_string.push_str(&format!("\"subcommands\": [{}]\n", subcommands));
+        json_help_string.push_str("}\n");
+        json_help_string
+    }}
+}
+
+/// Escape characters in strings to be JSON compatible.
+fn escape_json(value: &str) -> String {
+    value.replace("\n", r#"\n"#).replace("\"", r#"\""#)
+}

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -21,6 +21,7 @@ use {
 
 mod errors;
 mod help;
+mod help_json;
 mod parse_attrs;
 
 /// Entrypoint for `#[derive(FromArgs)]`.
@@ -324,7 +325,9 @@ fn impl_from_args_struct_from_args<'a>(
 
     // Identifier referring to a value containing the name of the current command as an `&[&str]`.
     let cmd_name_str_array_ident = syn::Ident::new("__cmd_name", impl_span);
-    let help = help::help(errors, cmd_name_str_array_ident, type_attrs, &fields, subcommand);
+    let help = help::help(errors, &cmd_name_str_array_ident, type_attrs, &fields, subcommand);
+    let help_json =
+        help_json::help_json(errors, &cmd_name_str_array_ident, type_attrs, &fields, subcommand);
 
     let method_impl = quote_spanned! { impl_span =>
         fn from_args(__cmd_name: &[&str], __args: &[&str])
@@ -352,6 +355,7 @@ fn impl_from_args_struct_from_args<'a>(
                 },
                 #parse_subcommands,
                 &|| #help,
+                &|| #help_json
             )?;
 
             let mut #missing_requirements_ident = argh::MissingRequirements::default();
@@ -436,7 +440,9 @@ fn impl_from_args_struct_redact_arg_values<'a>(
 
     // Identifier referring to a value containing the name of the current command as an `&[&str]`.
     let cmd_name_str_array_ident = syn::Ident::new("__cmd_name", impl_span);
-    let help = help::help(errors, cmd_name_str_array_ident, type_attrs, &fields, subcommand);
+    let help = help::help(errors, &cmd_name_str_array_ident, type_attrs, &fields, subcommand);
+    let help_json =
+        help_json::help_json(errors, &cmd_name_str_array_ident, type_attrs, &fields, subcommand);
 
     let method_impl = quote_spanned! { impl_span =>
         fn redact_arg_values(__cmd_name: &[&str], __args: &[&str]) -> std::result::Result<Vec<String>, argh::EarlyExit> {
@@ -462,6 +468,7 @@ fn impl_from_args_struct_redact_arg_values<'a>(
                 },
                 #redact_subcommands,
                 &|| #help,
+                &|| #help_json
             )?;
 
             let mut #missing_requirements_ident = argh::MissingRequirements::default();


### PR DESCRIPTION
* Adding --help-json to get JSON encoded help message

This adds the `--help-json` flag which prints the help information
encoded in a JSON object. This enables template engines to render
the help information in other formats such as markdown.

* Adding --help-json to get JSON encoded help message

This adds the `--help-json` flag which prints the help information
encoded in a JSON object. This enables template engines to render
the help information in other formats such as markdown.