### PR TITLE
allow alphanumeric strings in `long` attribute

### DIFF
--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -480,7 +480,7 @@ impl From<String> for EarlyExit {
 
 /// Extract the base cmd from a path
 fn cmd<'a>(default: &'a str, path: &'a str) -> &'a str {
-    std::path::Path::new(path).file_name().map(|s| s.to_str()).flatten().unwrap_or(default)
+    std::path::Path::new(path).file_name().and_then(|s| s.to_str()).unwrap_or(default)
 }
 
 /// Create a `FromArgs` type from the current process's `env::args`.

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -1369,3 +1369,17 @@ fn subcommand_does_not_panic() {
         argh::EarlyExit { output: "no subcommand name".into(), status: Err(()) },
     );
 }
+
+#[test]
+fn long_alphanumeric() {
+    #[derive(FromArgs)]
+    /// Short description
+    struct Cmd {
+        #[argh(option, long = "ac97")]
+        /// fooey
+        ac97: String,
+    }
+
+    let cmd = Cmd::from_args(&["cmdname"], &["--ac97", "bar"]).unwrap();
+    assert_eq!(cmd.ac97, "bar");
+}

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+use std::fmt::Write;
 use {
     crate::{
         errors::Errors,
@@ -102,7 +103,7 @@ pub(crate) fn help(
         for (code, text) in &ty_attrs.error_codes {
             format_lit.push('\n');
             format_lit.push_str(INDENT);
-            format_lit.push_str(&format!("{} {}", code, text.value()));
+            write!(format_lit, "{} {}", code, text.value()).unwrap();
         }
     }
 

--- a/argh_derive/src/parse_attrs.rs
+++ b/argh_derive/src/parse_attrs.rs
@@ -170,7 +170,7 @@ impl FieldAttrs {
         if !value.is_ascii() {
             errors.err(long, "Long names must be ASCII");
         }
-        if !value.chars().all(|c| c.is_lowercase() || c == '-') {
+        if !value.chars().all(|c| c.is_lowercase() || c == '-' || c.is_ascii_digit()) {
             errors.err(long, "Long names must be lowercase");
         }
     }


### PR DESCRIPTION
Argh already allows usage of field names such as `ac97` but not if
specified in `long` attribute