### PR TITLE
Support multiline docs

### DIFF
--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -310,19 +310,49 @@ fn multiline_doc_comment_description() {
         /// that is spread across
         /// a number of
         /// lines of comments.
+        ///
+        /// It can have multiple paragraphs
+        /// too and those should be
+        /// collapsed into one line and
+        /// reflowed.
+        ///
+        /// * It can also:         have lists
+        /// * That are:            not reflowed
+        ///
+        /// | And  | Tables |
+        /// |------|--------|
+        /// | work | too    |
+        ///
+        /// The basic rule is that lines that start with
+        /// an alphabetic character (a-zA-Z) are joined
+        /// to the previous line.
         _s: bool,
     }
 
+    // The \x20s are so that editors don't strip the trailing spaces.
     assert_help_string::<Cmd>(
-        r###"Usage: test_arg_0 [--s]
+        "Usage: test_arg_0 [--s]
 
 Short description
 
 Options:
   --s               a switch with a description that is spread across a number
                     of lines of comments.
+                   \x20
+                    It can have multiple paragraphs too and those should be
+                    collapsed into one line and reflowed.
+                   \x20
+                    * It can also:         have lists
+                    * That are:            not reflowed
+                   \x20
+                    | And  | Tables |
+                    |------|--------|
+                    | work | too    |
+                   \x20
+                    The basic rule is that lines that start with an alphabetic
+                    character (a-zA-Z) are joined to the previous line.
   --help, help      display usage information
-"###,
+",
     );
 }
 

--- a/argh_shared/src/lib.rs
+++ b/argh_shared/src/lib.rs
@@ -142,24 +142,26 @@ pub fn write_description(out: &mut String, cmd: &CommandInfo<'_>) {
         new_line(&mut current_line, out);
     }
 
-    let mut words = cmd.description.split(' ').peekable();
-    while let Some(first_word) = words.next() {
-        indent_description(&mut current_line);
-        current_line.push_str(first_word);
+    for line in cmd.description.lines() {
+        let mut words = line.split(' ').peekable();
+        while let Some(first_word) = words.next() {
+            indent_description(&mut current_line);
+            current_line.push_str(first_word);
 
-        'inner: while let Some(&word) = words.peek() {
-            if (char_len(&current_line) + char_len(word) + 1) > WRAP_WIDTH {
-                new_line(&mut current_line, out);
-                break 'inner;
-            } else {
-                // advance the iterator
-                let _ = words.next();
-                current_line.push(' ');
-                current_line.push_str(word);
+            while let Some(&word) = words.peek() {
+                if (char_len(&current_line) + char_len(word) + 1) > WRAP_WIDTH {
+                    new_line(&mut current_line, out);
+                    break;
+                } else {
+                    // advance the iterator
+                    let _ = words.next();
+                    current_line.push(' ');
+                    current_line.push_str(word);
+                }
             }
         }
+        new_line(&mut current_line, out);
     }
-    new_line(&mut current_line, out);
 }
 
 // Indent the current line in to DESCRIPTION_INDENT chars.


### PR DESCRIPTION
Adds basic support for multiline docstrings. The rule is basically if a line starts with an alphabetic character then it is joined to the previous line.

Fixes #121
Fixes #128