### PR TITLE
Help trait for exposing help information as JSON

### DIFF
--- a/argh/src/help.rs
+++ b/argh/src/help.rs
@@ -1,0 +1,330 @@
+// Copyright (c) 2022 Google LLC All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//! TODO
+
+use {
+    argh_shared::{write_description, CommandInfo, INDENT},
+    std::fmt,
+};
+
+const SECTION_SEPARATOR: &str = "\n\n";
+
+const HELP_FLAG: HelpFlagInfo = HelpFlagInfo {
+    short: None,
+    long: "--help",
+    description: "display usage information",
+    optionality: HelpOptionality::Optional,
+    kind: HelpFieldKind::Switch,
+};
+
+/// TODO
+pub trait Help {
+    /// TODO
+    const HELP_INFO: &'static HelpInfo;
+}
+
+/// TODO
+pub trait HelpSubCommands {
+    /// TODO
+    const HELP_INFO: &'static HelpSubCommandsInfo;
+}
+
+/// TODO
+pub trait HelpSubCommand {
+    /// TODO
+    const HELP_INFO: &'static HelpSubCommandInfo;
+}
+
+impl<T: HelpSubCommand> HelpSubCommands for T {
+    /// TODO
+    const HELP_INFO: &'static HelpSubCommandsInfo =
+        &HelpSubCommandsInfo { optional: false, commands: &[<T as HelpSubCommand>::HELP_INFO] };
+}
+
+/// TODO
+pub struct HelpInfo {
+    /// TODO
+    pub description: &'static str,
+    /// TODO
+    pub examples: &'static [fn(&[&str]) -> String],
+    /// TODO
+    pub notes: &'static [fn(&[&str]) -> String],
+    /// TODO
+    pub flags: &'static [&'static HelpFlagInfo],
+    /// TODO
+    pub positionals: &'static [&'static HelpPositionalInfo],
+    /// TODO
+    pub subcommand: Option<&'static HelpSubCommandsInfo>,
+    /// TODO
+    pub error_codes: &'static [(isize, &'static str)],
+}
+
+fn help_section(
+    out: &mut String,
+    command_name: &[&str],
+    heading: &str,
+    sections: &[fn(&[&str]) -> String],
+) {
+    if !sections.is_empty() {
+        out.push_str(SECTION_SEPARATOR);
+        for section_fn in sections {
+            let section = section_fn(command_name);
+
+            out.push_str(heading);
+            for line in section.split('\n') {
+                out.push('\n');
+                out.push_str(INDENT);
+                out.push_str(line);
+            }
+        }
+    }
+}
+
+impl HelpInfo {
+    /// TODO
+    pub fn help(&self, command_name: &[&str]) -> String {
+        let mut out = format!("Usage: {}", command_name.join(" "));
+
+        for positional in self.positionals {
+            out.push(' ');
+            positional.help_usage(&mut out);
+        }
+
+        for flag in self.flags {
+            out.push(' ');
+            flag.help_usage(&mut out);
+        }
+
+        if let Some(subcommand) = &self.subcommand {
+            out.push(' ');
+            if subcommand.optional {
+                out.push('[');
+            }
+            out.push_str("<command>");
+            if subcommand.optional {
+                out.push(']');
+            }
+            out.push_str(" [<args>]");
+        }
+
+        out.push_str(SECTION_SEPARATOR);
+
+        out.push_str(self.description);
+
+        if !self.positionals.is_empty() {
+            out.push_str(SECTION_SEPARATOR);
+            out.push_str("Positional Arguments:");
+            for positional in self.positionals {
+                positional.help_description(&mut out);
+            }
+        }
+
+        out.push_str(SECTION_SEPARATOR);
+        out.push_str("Options:");
+        for flag in self.flags {
+            flag.help_description(&mut out);
+        }
+
+        // Also include "help"
+        HELP_FLAG.help_description(&mut out);
+
+        if let Some(subcommand) = &self.subcommand {
+            out.push_str(SECTION_SEPARATOR);
+            out.push_str("Commands:");
+            for cmd in subcommand.commands {
+                let info = CommandInfo { name: cmd.name, description: cmd.info.description };
+                write_description(&mut out, &info);
+            }
+        }
+
+        help_section(&mut out, command_name, "Examples:", self.examples);
+
+        help_section(&mut out, command_name, "Notes:", self.notes);
+
+        if !self.error_codes.is_empty() {
+            out.push_str(SECTION_SEPARATOR);
+            out.push_str("Error codes:");
+            write_error_codes(&mut out, self.error_codes);
+        }
+
+        out.push('\n');
+
+        out
+    }
+}
+
+fn write_error_codes(out: &mut String, error_codes: &[(isize, &str)]) {
+    for (code, text) in error_codes {
+        out.push('\n');
+        out.push_str(INDENT);
+        out.push_str(&format!("{} {}", code, text));
+    }
+}
+
+impl fmt::Debug for HelpInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let examples = self.examples.iter().map(|f| f(&["{command_name}"])).collect::<Vec<_>>();
+        let notes = self.notes.iter().map(|f| f(&["{command_name}"])).collect::<Vec<_>>();
+        f.debug_struct("HelpInfo")
+            .field("description", &self.description)
+            .field("examples", &examples)
+            .field("notes", &notes)
+            .field("flags", &self.flags)
+            .field("positionals", &self.positionals)
+            .field("subcommand", &self.subcommand)
+            .field("error_codes", &self.error_codes)
+            .finish()
+    }
+}
+
+/// TODO
+#[derive(Debug, Default)]
+pub struct HelpSubCommandsInfo {
+    /// TODO
+    pub optional: bool,
+    /// TODO
+    pub commands: &'static [&'static HelpSubCommandInfo],
+}
+
+/// TODO
+#[derive(Debug)]
+pub struct HelpSubCommandInfo {
+    /// TODO
+    pub name: &'static str,
+    /// TODO
+    pub info: &'static HelpInfo,
+}
+
+/// TODO
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HelpOptionality {
+    /// TODO
+    None,
+    /// TODO
+    Optional,
+    /// TODO
+    Repeating,
+}
+
+impl HelpOptionality {
+    /// TODO
+    fn is_required(&self) -> bool {
+        matches!(self, HelpOptionality::None)
+    }
+}
+
+/// TODO
+#[derive(Debug)]
+pub struct HelpPositionalInfo {
+    /// TODO
+    pub name: &'static str,
+    /// TODO
+    pub description: &'static str,
+    /// TODO
+    pub optionality: HelpOptionality,
+}
+
+impl HelpPositionalInfo {
+    /// TODO
+    pub fn help_usage(&self, out: &mut String) {
+        if !self.optionality.is_required() {
+            out.push('[');
+        }
+
+        out.push('<');
+        out.push_str(self.name);
+
+        if self.optionality == HelpOptionality::Repeating {
+            out.push_str("...");
+        }
+
+        out.push('>');
+
+        if !self.optionality.is_required() {
+            out.push(']');
+        }
+    }
+
+    /// TODO
+    pub fn help_description(&self, out: &mut String) {
+        let info = CommandInfo { name: self.name, description: self.description };
+        write_description(out, &info);
+    }
+}
+
+/// TODO
+#[derive(Debug)]
+pub struct HelpFlagInfo {
+    /// TODO
+    pub short: Option<char>,
+    /// TODO
+    pub long: &'static str,
+    /// TODO
+    pub description: &'static str,
+    /// TODO
+    pub optionality: HelpOptionality,
+    /// TODO
+    pub kind: HelpFieldKind,
+}
+
+/// TODO
+#[derive(Debug)]
+pub enum HelpFieldKind {
+    /// TODO
+    Switch,
+    /// TODO
+    Option {
+        /// TODO
+        arg_name: &'static str,
+    },
+}
+
+impl HelpFlagInfo {
+    /// TODO
+    pub fn help_usage(&self, out: &mut String) {
+        if !self.optionality.is_required() {
+            out.push('[');
+        }
+
+        if let Some(short) = self.short {
+            out.push('-');
+            out.push(short);
+        } else {
+            out.push_str(self.long);
+        }
+
+        match self.kind {
+            HelpFieldKind::Switch => {}
+            HelpFieldKind::Option { arg_name } => {
+                out.push_str(" <");
+                out.push_str(arg_name);
+
+                if self.optionality == HelpOptionality::Repeating {
+                    out.push_str("...");
+                }
+
+                out.push('>');
+            }
+        }
+
+        if !self.optionality.is_required() {
+            out.push(']');
+        }
+    }
+
+    /// TODO
+    pub fn help_description(&self, out: &mut String) {
+        let mut name = String::new();
+        if let Some(short) = self.short {
+            name.push('-');
+            name.push(short);
+            name.push_str(", ");
+        }
+        name.push_str(self.long);
+
+        let info = CommandInfo { name: &name, description: self.description };
+        write_description(out, &info);
+    }
+}

--- a/argh/src/help.rs
+++ b/argh/src/help.rs
@@ -2,329 +2,40 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//! TODO
+use crate::{EarlyExit, FromArgs, HelpInfo, HelpSubCommandInfo, HelpSubCommandsInfo};
 
-use {
-    argh_shared::{write_description, CommandInfo, INDENT},
-    std::fmt,
-};
-
-const SECTION_SEPARATOR: &str = "\n\n";
-
-const HELP_FLAG: HelpFlagInfo = HelpFlagInfo {
-    short: None,
-    long: "--help",
-    description: "display usage information",
-    optionality: HelpOptionality::Optional,
-    kind: HelpFieldKind::Switch,
-};
-
-/// TODO
-pub trait Help {
-    /// TODO
+/// Trait to expose the command line help information in JSON format.
+///
+pub trait Help: FromArgs {
+    /// Help info extracted from the argh information provided by the
+    /// FromArgs trait.
     const HELP_INFO: &'static HelpInfo;
+
+    /// Returns a JSON encoded string of the usage information. This is intended to
+    /// create a "machine readable" version of the help text to enable reference
+    /// documentation generation.
+    fn help_json_from_args(strs: &[&str]) -> Result<String, EarlyExit> {
+        Ok(Self::HELP_INFO.help_json_from_args(strs))
+    }
 }
 
-/// TODO
+/// HelpSubCommands is used to store the Help information for
+/// subcommands declared.
 pub trait HelpSubCommands {
-    /// TODO
+    /// Help info extracted from the argh information provided by the
+    /// FromArgs trait.
     const HELP_INFO: &'static HelpSubCommandsInfo;
 }
 
-/// TODO
+/// The help information for a single subcommand.
 pub trait HelpSubCommand {
-    /// TODO
+    /// Help info extracted from the argh information provided by the
+    /// FromArgs trait.
     const HELP_INFO: &'static HelpSubCommandInfo;
 }
 
 impl<T: HelpSubCommand> HelpSubCommands for T {
-    /// TODO
+    /// The HELPINFO is the collection of HelpSubCommand objects.
     const HELP_INFO: &'static HelpSubCommandsInfo =
         &HelpSubCommandsInfo { optional: false, commands: &[<T as HelpSubCommand>::HELP_INFO] };
-}
-
-/// TODO
-pub struct HelpInfo {
-    /// TODO
-    pub description: &'static str,
-    /// TODO
-    pub examples: &'static [fn(&[&str]) -> String],
-    /// TODO
-    pub notes: &'static [fn(&[&str]) -> String],
-    /// TODO
-    pub flags: &'static [&'static HelpFlagInfo],
-    /// TODO
-    pub positionals: &'static [&'static HelpPositionalInfo],
-    /// TODO
-    pub subcommand: Option<&'static HelpSubCommandsInfo>,
-    /// TODO
-    pub error_codes: &'static [(isize, &'static str)],
-}
-
-fn help_section(
-    out: &mut String,
-    command_name: &[&str],
-    heading: &str,
-    sections: &[fn(&[&str]) -> String],
-) {
-    if !sections.is_empty() {
-        out.push_str(SECTION_SEPARATOR);
-        for section_fn in sections {
-            let section = section_fn(command_name);
-
-            out.push_str(heading);
-            for line in section.split('\n') {
-                out.push('\n');
-                out.push_str(INDENT);
-                out.push_str(line);
-            }
-        }
-    }
-}
-
-impl HelpInfo {
-    /// TODO
-    pub fn help(&self, command_name: &[&str]) -> String {
-        let mut out = format!("Usage: {}", command_name.join(" "));
-
-        for positional in self.positionals {
-            out.push(' ');
-            positional.help_usage(&mut out);
-        }
-
-        for flag in self.flags {
-            out.push(' ');
-            flag.help_usage(&mut out);
-        }
-
-        if let Some(subcommand) = &self.subcommand {
-            out.push(' ');
-            if subcommand.optional {
-                out.push('[');
-            }
-            out.push_str("<command>");
-            if subcommand.optional {
-                out.push(']');
-            }
-            out.push_str(" [<args>]");
-        }
-
-        out.push_str(SECTION_SEPARATOR);
-
-        out.push_str(self.description);
-
-        if !self.positionals.is_empty() {
-            out.push_str(SECTION_SEPARATOR);
-            out.push_str("Positional Arguments:");
-            for positional in self.positionals {
-                positional.help_description(&mut out);
-            }
-        }
-
-        out.push_str(SECTION_SEPARATOR);
-        out.push_str("Options:");
-        for flag in self.flags {
-            flag.help_description(&mut out);
-        }
-
-        // Also include "help"
-        HELP_FLAG.help_description(&mut out);
-
-        if let Some(subcommand) = &self.subcommand {
-            out.push_str(SECTION_SEPARATOR);
-            out.push_str("Commands:");
-            for cmd in subcommand.commands {
-                let info = CommandInfo { name: cmd.name, description: cmd.info.description };
-                write_description(&mut out, &info);
-            }
-        }
-
-        help_section(&mut out, command_name, "Examples:", self.examples);
-
-        help_section(&mut out, command_name, "Notes:", self.notes);
-
-        if !self.error_codes.is_empty() {
-            out.push_str(SECTION_SEPARATOR);
-            out.push_str("Error codes:");
-            write_error_codes(&mut out, self.error_codes);
-        }
-
-        out.push('\n');
-
-        out
-    }
-}
-
-fn write_error_codes(out: &mut String, error_codes: &[(isize, &str)]) {
-    for (code, text) in error_codes {
-        out.push('\n');
-        out.push_str(INDENT);
-        out.push_str(&format!("{} {}", code, text));
-    }
-}
-
-impl fmt::Debug for HelpInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let examples = self.examples.iter().map(|f| f(&["{command_name}"])).collect::<Vec<_>>();
-        let notes = self.notes.iter().map(|f| f(&["{command_name}"])).collect::<Vec<_>>();
-        f.debug_struct("HelpInfo")
-            .field("description", &self.description)
-            .field("examples", &examples)
-            .field("notes", &notes)
-            .field("flags", &self.flags)
-            .field("positionals", &self.positionals)
-            .field("subcommand", &self.subcommand)
-            .field("error_codes", &self.error_codes)
-            .finish()
-    }
-}
-
-/// TODO
-#[derive(Debug, Default)]
-pub struct HelpSubCommandsInfo {
-    /// TODO
-    pub optional: bool,
-    /// TODO
-    pub commands: &'static [&'static HelpSubCommandInfo],
-}
-
-/// TODO
-#[derive(Debug)]
-pub struct HelpSubCommandInfo {
-    /// TODO
-    pub name: &'static str,
-    /// TODO
-    pub info: &'static HelpInfo,
-}
-
-/// TODO
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum HelpOptionality {
-    /// TODO
-    None,
-    /// TODO
-    Optional,
-    /// TODO
-    Repeating,
-}
-
-impl HelpOptionality {
-    /// TODO
-    fn is_required(&self) -> bool {
-        matches!(self, HelpOptionality::None)
-    }
-}
-
-/// TODO
-#[derive(Debug)]
-pub struct HelpPositionalInfo {
-    /// TODO
-    pub name: &'static str,
-    /// TODO
-    pub description: &'static str,
-    /// TODO
-    pub optionality: HelpOptionality,
-}
-
-impl HelpPositionalInfo {
-    /// TODO
-    pub fn help_usage(&self, out: &mut String) {
-        if !self.optionality.is_required() {
-            out.push('[');
-        }
-
-        out.push('<');
-        out.push_str(self.name);
-
-        if self.optionality == HelpOptionality::Repeating {
-            out.push_str("...");
-        }
-
-        out.push('>');
-
-        if !self.optionality.is_required() {
-            out.push(']');
-        }
-    }
-
-    /// TODO
-    pub fn help_description(&self, out: &mut String) {
-        let info = CommandInfo { name: self.name, description: self.description };
-        write_description(out, &info);
-    }
-}
-
-/// TODO
-#[derive(Debug)]
-pub struct HelpFlagInfo {
-    /// TODO
-    pub short: Option<char>,
-    /// TODO
-    pub long: &'static str,
-    /// TODO
-    pub description: &'static str,
-    /// TODO
-    pub optionality: HelpOptionality,
-    /// TODO
-    pub kind: HelpFieldKind,
-}
-
-/// TODO
-#[derive(Debug)]
-pub enum HelpFieldKind {
-    /// TODO
-    Switch,
-    /// TODO
-    Option {
-        /// TODO
-        arg_name: &'static str,
-    },
-}
-
-impl HelpFlagInfo {
-    /// TODO
-    pub fn help_usage(&self, out: &mut String) {
-        if !self.optionality.is_required() {
-            out.push('[');
-        }
-
-        if let Some(short) = self.short {
-            out.push('-');
-            out.push(short);
-        } else {
-            out.push_str(self.long);
-        }
-
-        match self.kind {
-            HelpFieldKind::Switch => {}
-            HelpFieldKind::Option { arg_name } => {
-                out.push_str(" <");
-                out.push_str(arg_name);
-
-                if self.optionality == HelpOptionality::Repeating {
-                    out.push_str("...");
-                }
-
-                out.push('>');
-            }
-        }
-
-        if !self.optionality.is_required() {
-            out.push(']');
-        }
-    }
-
-    /// TODO
-    pub fn help_description(&self, out: &mut String) {
-        let mut name = String::new();
-        if let Some(short) = self.short {
-            name.push('-');
-            name.push(short);
-            name.push_str(", ");
-        }
-        name.push_str(self.long);
-
-        let info = CommandInfo { name: &name, description: self.description };
-        write_description(out, &info);
-    }
 }

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -265,9 +265,12 @@
 
 #![deny(missing_docs)]
 
+mod help;
+
 use std::str::FromStr;
 
 pub use {
+    crate::help::{Help, HelpSubCommand, HelpSubCommands},
     argh_derive::{FromArgs, Help},
     argh_shared::{HelpFieldKind, HelpFlagInfo, HelpOptionality, HelpPositionalInfo},
 };
@@ -275,13 +278,13 @@ pub use {
 /// Information about a particular command used for output.
 pub type CommandInfo = argh_shared::CommandInfo<'static>;
 
-/// TODO
+/// Information desribing the help for a command.
 pub type HelpInfo = argh_shared::HelpInfo<'static>;
 
-/// TODO
+/// Information desribing the help for a collection of subcommands.
 pub type HelpSubCommandsInfo = argh_shared::HelpSubCommandsInfo<'static>;
 
-/// TODO
+/// Information desribing the help for a single subcommand.
 pub type HelpSubCommandInfo = argh_shared::HelpSubCommandInfo<'static>;
 
 /// Types which can be constructed from a set of commandline arguments.
@@ -612,50 +615,6 @@ pub struct EarlyExit {
     // TODO replace with std::process::ExitCode when stable.
     pub status: Result<(), ()>,
 }
-
-/// TODO
-pub trait Help : FromArgs {
-    /// TODO
-    const HELP_INFO: &'static HelpInfo;
-
-
-            /// Returns a JSON encoded string of the usage information. This is intended to
-    /// create a "machine readable" version of the help text to enable reference
-    /// documentation generation.
-    fn help_json_from_args(strs: &[&str]) -> Result<String, EarlyExit> {
-        Ok(Self::HELP_INFO.help_json_from_args(strs))
-    }
-}
-
-    /// Returns a JSON encoded string of the usage information based on the command line
-    /// found in argv, identical to `::from_env()`. This is intended to
-    /// create a "machine readable" version of the help text to enable reference
-    /// documentation generation.
-   pub fn help_json<T:Help>() -> Result<String, EarlyExit> {
-        let strings: Vec<String> = std::env::args().collect();
-        //let cmd = cmd(&strings[0], &strings[0]);
-        let strs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
-        T::help_json_from_args(strs.as_slice())
-
-    }
-/// TODO
-pub trait HelpSubCommands {
-    /// TODO
-    const HELP_INFO: &'static HelpSubCommandsInfo;
-}
-
-/// TODO
-pub trait HelpSubCommand {
-    /// TODO
-    const HELP_INFO: &'static HelpSubCommandInfo;
-}
-
-impl<T: HelpSubCommand> HelpSubCommands for T {
-    /// TODO
-    const HELP_INFO: &'static HelpSubCommandsInfo =
-        &HelpSubCommandsInfo { optional: false, commands: &[<T as HelpSubCommand>::HELP_INFO] };
-}
-
 
 impl From<String> for EarlyExit {
     fn from(err_msg: String) -> Self {

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -267,10 +267,22 @@
 
 use std::str::FromStr;
 
-pub use argh_derive::FromArgs;
+pub use {
+    argh_derive::{FromArgs, Help},
+    argh_shared::{HelpFieldKind, HelpFlagInfo, HelpOptionality, HelpPositionalInfo},
+};
 
 /// Information about a particular command used for output.
 pub type CommandInfo = argh_shared::CommandInfo<'static>;
+
+/// TODO
+pub type HelpInfo = argh_shared::HelpInfo<'static>;
+
+/// TODO
+pub type HelpSubCommandsInfo = argh_shared::HelpSubCommandsInfo<'static>;
+
+/// TODO
+pub type HelpSubCommandInfo = argh_shared::HelpSubCommandInfo<'static>;
 
 /// Types which can be constructed from a set of commandline arguments.
 pub trait FromArgs: Sized {
@@ -600,6 +612,50 @@ pub struct EarlyExit {
     // TODO replace with std::process::ExitCode when stable.
     pub status: Result<(), ()>,
 }
+
+/// TODO
+pub trait Help : FromArgs {
+    /// TODO
+    const HELP_INFO: &'static HelpInfo;
+
+
+            /// Returns a JSON encoded string of the usage information. This is intended to
+    /// create a "machine readable" version of the help text to enable reference
+    /// documentation generation.
+    fn help_json_from_args(strs: &[&str]) -> Result<String, EarlyExit> {
+        Ok(Self::HELP_INFO.help_json_from_args(strs))
+    }
+}
+
+    /// Returns a JSON encoded string of the usage information based on the command line
+    /// found in argv, identical to `::from_env()`. This is intended to
+    /// create a "machine readable" version of the help text to enable reference
+    /// documentation generation.
+   pub fn help_json<T:Help>() -> Result<String, EarlyExit> {
+        let strings: Vec<String> = std::env::args().collect();
+        //let cmd = cmd(&strings[0], &strings[0]);
+        let strs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
+        T::help_json_from_args(strs.as_slice())
+
+    }
+/// TODO
+pub trait HelpSubCommands {
+    /// TODO
+    const HELP_INFO: &'static HelpSubCommandsInfo;
+}
+
+/// TODO
+pub trait HelpSubCommand {
+    /// TODO
+    const HELP_INFO: &'static HelpSubCommandInfo;
+}
+
+impl<T: HelpSubCommand> HelpSubCommands for T {
+    /// TODO
+    const HELP_INFO: &'static HelpSubCommandsInfo =
+        &HelpSubCommandsInfo { optional: false, commands: &[<T as HelpSubCommand>::HELP_INFO] };
+}
+
 
 impl From<String> for EarlyExit {
     fn from(err_msg: String) -> Self {

--- a/argh/tests/help_json_tests.rs
+++ b/argh/tests/help_json_tests.rs
@@ -1,0 +1,702 @@
+#![cfg(test)]
+// Copyright (c) 2020 Google LLC All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+use std::path::PathBuf;
+
+use {argh:: {FromArgs, Help}, std::fmt::Debug};
+
+#[test]
+fn help_json_test_subcommand() {
+    #[derive(FromArgs, Help, PartialEq, Debug)]
+    /// Top-level command.
+    struct TopLevel {
+        #[argh(subcommand)]
+        nested: MySubCommandEnum,
+    }
+
+    #[derive(FromArgs, Help, PartialEq, Debug)]
+    #[argh(subcommand)]
+    enum MySubCommandEnum {
+        One(SubCommandOne),
+        Two(SubCommandTwo),
+    }
+
+    #[derive(FromArgs, Help, PartialEq, Debug)]
+    /// First subcommand.
+    #[argh(subcommand, name = "one")]
+    struct SubCommandOne {
+        #[argh(option)]
+        /// how many x
+        x: usize,
+    }
+
+    #[derive(FromArgs, Help, PartialEq, Debug)]
+    /// Second subcommand.
+    #[argh(subcommand, name = "two")]
+    struct SubCommandTwo {
+        #[argh(switch)]
+        /// whether to fooey
+        fooey: bool,
+    }
+
+    assert_help_json_string::<TopLevel>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 <command> [<args>]",
+"description": "Top-level command.",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": [{
+"name": "one",
+"usage": "test_arg_0 one --x <x>",
+"description": "First subcommand.",
+"flags": [{"short": "", "long": "--x", "description": "how many x", "arg_name": "x", "optionality": "required"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+,
+{
+"name": "two",
+"usage": "test_arg_0 two [--fooey]",
+"description": "Second subcommand.",
+"flags": [{"short": "", "long": "--fooey", "description": "whether to fooey", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+]
+}
+"###,
+    );
+
+    assert_help_json_string::<SubCommandOne>(
+        vec!["one"],
+        r###"{
+"name": "one",
+"usage": "test_arg_0 one --x <x>",
+"description": "First subcommand.",
+"flags": [{"short": "", "long": "--x", "description": "how many x", "arg_name": "x", "optionality": "required"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_multiline_doc_comment() {
+    #[derive(FromArgs, Help)]
+    /// Short description
+    struct Cmd {
+        #[argh(switch)]
+        /// a switch with a description
+        /// that is spread across
+        /// a number of
+        /// lines of comments.
+        _s: bool,
+    }
+    assert_help_json_string::<Cmd>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 [--s]",
+"description": "Short description",
+"flags": [{"short": "", "long": "--s", "description": "a switch with a description that is spread across a number of lines of comments.", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_basic_args() {
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    /// Basic command args demonstrating multiple types and cardinality. "With quotes"
+    struct Basic {
+        /// should the power be on. "Quoted value" should work too.
+        #[argh(switch)]
+        power: bool,
+
+        /// option that is required because of no default and not Option<>.
+        #[argh(option, long = "required")]
+        required_flag: String,
+
+        /// optional speed if not specified it is None.
+        #[argh(option, short = 's')]
+        speed: Option<u8>,
+
+        /// repeatable option.
+        #[argh(option, arg_name = "url")]
+        link: Vec<String>,
+    }
+    assert_help_json_string::<Basic>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 [--power] --required <required> [-s <speed>] [--link <url...>]",
+"description": "Basic command args demonstrating multiple types and cardinality. \"With quotes\"",
+"flags": [{"short": "", "long": "--power", "description": "should the power be on. \"Quoted value\" should work too.", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--required", "description": "option that is required because of no default and not Option<>.", "arg_name": "required", "optionality": "required"},
+{"short": "s", "long": "--speed", "description": "optional speed if not specified it is None.", "arg_name": "speed", "optionality": "optional"},
+{"short": "", "long": "--link", "description": "repeatable option.", "arg_name": "url", "optionality": "repeating"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_positional_args() {
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    /// Command with positional args demonstrating. "With quotes"
+    struct Positional {
+        /// the "root" position.
+        #[argh(positional, arg_name = "root")]
+        root_value: String,
+
+        /// trunk value
+        #[argh(positional)]
+        trunk: String,
+
+        /// leaves. There can be many leaves.
+        #[argh(positional)]
+        leaves: Vec<String>,
+    }
+    assert_help_json_string::<Positional>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 <root> <trunk> [<leaves...>]",
+"description": "Command with positional args demonstrating. \"With quotes\"",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [{"name": "root", "description": "the \"root\" position.", "optionality": "required"},
+{"name": "trunk", "description": "trunk value", "optionality": "required"},
+{"name": "leaves", "description": "leaves. There can be many leaves.", "optionality": "repeating"}],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_optional_positional_args() {
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    /// Command with positional args demonstrating last value is optional
+    struct Positional {
+        /// the "root" position.
+        #[argh(positional, arg_name = "root")]
+        root_value: String,
+
+        /// trunk value
+        #[argh(positional)]
+        trunk: String,
+
+        /// leaves. There can be an optional leaves.
+        #[argh(positional)]
+        leaves: Option<String>,
+    }
+    assert_help_json_string::<Positional>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 <root> <trunk> [<leaves>]",
+"description": "Command with positional args demonstrating last value is optional",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [{"name": "root", "description": "the \"root\" position.", "optionality": "required"},
+{"name": "trunk", "description": "trunk value", "optionality": "required"},
+{"name": "leaves", "description": "leaves. There can be an optional leaves.", "optionality": "optional"}],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_default_positional_args() {
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    /// Command with positional args demonstrating last value is defaulted.
+    struct Positional {
+        /// the "root" position.
+        #[argh(positional, arg_name = "root")]
+        root_value: String,
+
+        /// trunk value
+        #[argh(positional)]
+        trunk: String,
+
+        /// leaves. There can be one leaf, defaults to hello.
+        #[argh(positional, default = "String::from(\"hello\")")]
+        leaves: String,
+    }
+    assert_help_json_string::<Positional>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 <root> <trunk> [<leaves>]",
+"description": "Command with positional args demonstrating last value is defaulted.",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [{"name": "root", "description": "the \"root\" position.", "optionality": "required"},
+{"name": "trunk", "description": "trunk value", "optionality": "required"},
+{"name": "leaves", "description": "leaves. There can be one leaf, defaults to hello.", "optionality": "optional"}],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_notes_examples_errors() {
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    /// Command with Examples and usage Notes, including error codes.
+    #[argh(
+        note = r##"
+    These usage notes appear for {command_name} and how to best use it.
+    The formatting should be preserved.
+    one
+    two
+    three then a blank
+    
+    and one last line with "quoted text"."##,
+        example = r##"
+    Use the command with 1 file:
+
+    `{command_name} /path/to/file`
+
+    Use it with a "wildcard":
+
+    `{command_name} /path/to/*`
+
+     a blank line
+    
+    and one last line with "quoted text"."##,
+        error_code(0, "Success"),
+        error_code(1, "General Error"),
+        error_code(2, "Some error with \"quotes\"")
+    )]
+    struct NotesExamplesErrors {
+        /// the "root" position.
+        #[argh(positional, arg_name = "files")]
+        fields: Vec<PathBuf>,
+    }
+    assert_help_json_string::<NotesExamplesErrors>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 [<files...>]",
+"description": "Command with Examples and usage Notes, including error codes.",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [{"name": "files", "description": "the \"root\" position.", "optionality": "repeating"}],
+"examples": "\n    Use the command with 1 file:\n\n    `test_arg_0 /path/to/file`\n\n    Use it with a \"wildcard\":\n\n    `test_arg_0 /path/to/*`\n\n     a blank line\n    \n    and one last line with \"quoted text\".",
+"notes": "\n    These usage notes appear for test_arg_0 and how to best use it.\n    The formatting should be preserved.\n    one\n    two\n    three then a blank\n    \n    and one last line with \"quoted text\".",
+"error_codes": [{"name": "0", "description": "Success"},
+{"name": "1", "description": "General Error"},
+{"name": "2", "description": "Some error with \"quotes\""}],
+"subcommands": []
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_subcommands() {
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    ///Top level command with "subcommands".
+    struct TopLevel {
+        /// show verbose output
+        #[argh(switch)]
+        verbose: bool,
+
+        /// this doc comment does not appear anywhere.
+        #[argh(subcommand)]
+        cmd: SubcommandEnum,
+    }
+
+    #[derive(FromArgs, Help)]
+    #[argh(subcommand)]
+    /// Doc comments for subcommand enums does not appear in the help text.
+    enum SubcommandEnum {
+        Command1(Command1Args),
+        Command2(Command2Args),
+        Command3(Command3Args),
+    }
+
+    /// Command1 args are used for Command1.
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    #[argh(subcommand, name = "one")]
+    struct Command1Args {
+        /// the "root" position.
+        #[argh(positional, arg_name = "root")]
+        root_value: String,
+
+        /// trunk value
+        #[argh(positional)]
+        trunk: String,
+
+        /// leaves. There can be zero leaves, defaults to hello.
+        #[argh(positional, default = "String::from(\"hello\")")]
+        leaves: String,
+    }
+    /// Command2 args are used for Command2.
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    #[argh(subcommand, name = "two")]
+    struct Command2Args {
+        /// should the power be on. "Quoted value" should work too.
+        #[argh(switch)]
+        power: bool,
+
+        /// option that is required because of no default and not Option<>.
+        #[argh(option, long = "required")]
+        required_flag: String,
+
+        /// optional speed if not specified it is None.
+        #[argh(option, short = 's')]
+        speed: Option<u8>,
+
+        /// repeatable option.
+        #[argh(option, arg_name = "url")]
+        link: Vec<String>,
+    }
+    /// Command3 args are used for Command3 which has no options or arguments.
+    #[derive(FromArgs, Help)]
+    #[argh(subcommand, name = "three")]
+    struct Command3Args {}
+
+    assert_help_json_string::<TopLevel>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 [--verbose] <command> [<args>]",
+"description": "Top level command with \"subcommands\".",
+"flags": [{"short": "", "long": "--verbose", "description": "show verbose output", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": [{
+"name": "one",
+"usage": "test_arg_0 one <root> <trunk> [<leaves>]",
+"description": "Command1 args are used for Command1.",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [{"name": "root", "description": "the \"root\" position.", "optionality": "required"},
+{"name": "trunk", "description": "trunk value", "optionality": "required"},
+{"name": "leaves", "description": "leaves. There can be zero leaves, defaults to hello.", "optionality": "optional"}],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+,
+{
+"name": "two",
+"usage": "test_arg_0 two [--power] --required <required> [-s <speed>] [--link <url...>]",
+"description": "Command2 args are used for Command2.",
+"flags": [{"short": "", "long": "--power", "description": "should the power be on. \"Quoted value\" should work too.", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--required", "description": "option that is required because of no default and not Option<>.", "arg_name": "required", "optionality": "required"},
+{"short": "s", "long": "--speed", "description": "optional speed if not specified it is None.", "arg_name": "speed", "optionality": "optional"},
+{"short": "", "long": "--link", "description": "repeatable option.", "arg_name": "url", "optionality": "repeating"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+,
+{
+"name": "three",
+"usage": "test_arg_0 three",
+"description": "Command3 args are used for Command3 which has no options or arguments.",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+]
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_subcommand_notes_examples() {
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    ///Top level command with "subcommands".
+    #[argh(
+        note = "Top level note",
+        example = "Top level example",
+        error_code(0, "Top level success")
+    )]
+    struct TopLevel {
+        /// show verbose output
+        #[argh(switch)]
+        verbose: bool,
+
+        /// this doc comment does not appear anywhere.
+        #[argh(subcommand)]
+        cmd: SubcommandEnum,
+    }
+
+    #[derive(FromArgs, Help)]
+    #[argh(subcommand)]
+    /// Doc comments for subcommand enums does not appear in the help text.
+    enum SubcommandEnum {
+        Command1(Command1Args),
+    }
+
+    /// Command1 args are used for subcommand one.
+    #[allow(dead_code)]
+    #[derive(FromArgs, Help)]
+    #[argh(
+        subcommand,
+        name = "one",
+        note = "{command_name} is used as a subcommand of \"Top level\"",
+        example = "\"Typical\" usage is `{command_name}`.",
+        error_code(0, "one level success")
+    )]
+    struct Command1Args {
+        /// the "root" position.
+        #[argh(positional, arg_name = "root")]
+        root_value: String,
+
+        /// trunk value
+        #[argh(positional)]
+        trunk: String,
+
+        /// leaves. There can be many leaves.
+        #[argh(positional, default = "String::from(\"hello\")")]
+        leaves: String,
+    }
+
+    assert_help_json_string::<TopLevel>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 [--verbose] <command> [<args>]",
+"description": "Top level command with \"subcommands\".",
+"flags": [{"short": "", "long": "--verbose", "description": "show verbose output", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "Top level example",
+"notes": "Top level note",
+"error_codes": [{"name": "0", "description": "Top level success"}],
+"subcommands": [{
+"name": "one",
+"usage": "test_arg_0 one <root> <trunk> [<leaves>]",
+"description": "Command1 args are used for subcommand one.",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [{"name": "root", "description": "the \"root\" position.", "optionality": "required"},
+{"name": "trunk", "description": "trunk value", "optionality": "required"},
+{"name": "leaves", "description": "leaves. There can be many leaves.", "optionality": "optional"}],
+"examples": "\"Typical\" usage is `test_arg_0 one`.",
+"notes": "test_arg_0 one is used as a subcommand of \"Top level\"",
+"error_codes": [{"name": "0", "description": "one level success"}],
+"subcommands": []
+}
+]
+}
+"###,
+    );
+
+    assert_help_json_string::<Command1Args>(
+        vec!["one"],
+        r###"{
+"name": "one",
+"usage": "test_arg_0 one <root> <trunk> [<leaves>]",
+"description": "Command1 args are used for subcommand one.",
+"flags": [{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [{"name": "root", "description": "the \"root\" position.", "optionality": "required"},
+{"name": "trunk", "description": "trunk value", "optionality": "required"},
+{"name": "leaves", "description": "leaves. There can be many leaves.", "optionality": "optional"}],
+"examples": "\"Typical\" usage is `test_arg_0 one`.",
+"notes": "test_arg_0 one is used as a subcommand of \"Top level\"",
+"error_codes": [{"name": "0", "description": "one level success"}],
+"subcommands": []
+}
+"###,
+    );
+}
+
+#[test]
+fn help_json_test_example() {
+    #[derive(FromArgs, Help, PartialEq, Debug)]
+    #[argh(
+        description = "Destroy the contents of <file> with a specific \"method of destruction\".",
+        example = "Scribble 'abc' and then run |grind|.\n$ {command_name} -s 'abc' grind old.txt taxes.cp",
+        note = "Use `{command_name} help <command>` for details on [<args>] for a subcommand.",
+        error_code(2, "The blade is too dull."),
+        error_code(3, "Out of fuel.")
+    )]
+    struct HelpExample {
+        /// force, ignore minor errors. This description is so long that it wraps to the next line.
+        #[argh(switch, short = 'f')]
+        force: bool,
+
+        /// documentation
+        #[argh(switch)]
+        really_really_really_long_name_for_pat: bool,
+
+        /// write <scribble> repeatedly
+        #[argh(option, short = 's')]
+        scribble: String,
+
+        /// say more. Defaults to $BLAST_VERBOSE.
+        #[argh(switch, short = 'v')]
+        verbose: bool,
+
+        #[argh(subcommand)]
+        command: HelpExampleSubCommands,
+    }
+
+    #[derive(FromArgs, Help, PartialEq, Debug)]
+    #[argh(subcommand)]
+    enum HelpExampleSubCommands {
+        BlowUp(BlowUp),
+        Grind(GrindCommand),
+    }
+
+    #[derive(FromArgs,Help, PartialEq, Debug)]
+    #[argh(subcommand, name = "blow-up")]
+    /// explosively separate
+    struct BlowUp {
+        /// blow up bombs safely
+        #[argh(switch)]
+        safely: bool,
+    }
+
+    #[derive(FromArgs, Help, PartialEq, Debug)]
+    #[argh(subcommand, name = "grind", description = "make smaller by many small cuts")]
+    struct GrindCommand {
+        /// wear a visor while grinding
+        #[argh(switch)]
+        safely: bool,
+    }
+
+    assert_help_json_string::<HelpExample>(
+        vec![],
+        r###"{
+"name": "test_arg_0",
+"usage": "test_arg_0 [-f] [--really-really-really-long-name-for-pat] -s <scribble> [-v] <command> [<args>]",
+"description": "Destroy the contents of <file> with a specific \"method of destruction\".",
+"flags": [{"short": "f", "long": "--force", "description": "force, ignore minor errors. This description is so long that it wraps to the next line.", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--really-really-really-long-name-for-pat", "description": "documentation", "arg_name": "", "optionality": "optional"},
+{"short": "s", "long": "--scribble", "description": "write <scribble> repeatedly", "arg_name": "scribble", "optionality": "required"},
+{"short": "v", "long": "--verbose", "description": "say more. Defaults to $BLAST_VERBOSE.", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "Scribble 'abc' and then run |grind|.\n$ test_arg_0 -s 'abc' grind old.txt taxes.cp",
+"notes": "Use `test_arg_0 help <command>` for details on [<args>] for a subcommand.",
+"error_codes": [{"name": "2", "description": "The blade is too dull."},
+{"name": "3", "description": "Out of fuel."}],
+"subcommands": [{
+"name": "blow-up",
+"usage": "test_arg_0 blow-up [--safely]",
+"description": "explosively separate",
+"flags": [{"short": "", "long": "--safely", "description": "blow up bombs safely", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+,
+{
+"name": "grind",
+"usage": "test_arg_0 grind [--safely]",
+"description": "make smaller by many small cuts",
+"flags": [{"short": "", "long": "--safely", "description": "wear a visor while grinding", "arg_name": "", "optionality": "optional"},
+{"short": "", "long": "--help", "description": "display usage information", "arg_name": "", "optionality": "optional"}],
+"positional": [],
+"examples": "",
+"notes": "",
+"error_codes": [],
+"subcommands": []
+}
+]
+}
+"###,
+    );
+}
+
+/*
+{
+\"name\": \"test_arg_0\",
+\"usage\": \"test_arg_0 [-f] [--really-really-really-long-name-for-pat] -s <scribble> [-v] <command> [<args>]\",
+\"description\": \"Destroy the contents of <file> with a specific \\\"method of destruction\\\".\",
+\"flags\": [{\"short\": \"f\", \"long\": \"--force\", \"description\": \"force, ignore minor errors. This description is so long that it wraps to the next line.\", \"arg_name\": \"\", \"optionality\": \"optional\"},
+{\"short\": \"\", \"long\": \"--really-really-really-long-name-for-pat\", \"description\": \"documentation\", \"arg_name\": \"\", \"optionality\": \"optional\"},
+{\"short\": \"s\", \"long\": \"--scribble\", \"description\": \"write <scribble> repeatedly\", \"arg_name\": \"scribble\", \"optionality\": \"required\"},
+{\"short\": \"v\", \"long\": \"--verbose\", \"description\": \"say more. Defaults to $BLAST_VERBOSE.\", \"arg_name\": \"\", \"optionality\": \"optional\"},
+{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}]
+,\n\"positional\": [],
+\"examples\": \"Scribble 'abc' and then run |grind|.\\n$ test_arg_0 -s 'abc' grind old.txt taxes.cp\",\n\"notes\": \"Use `test_arg_0 help <command>` for details on [<args>] for a subcommand.\",
+\"error_codes\": [{\"name\": \"2\", \"description\": \"The blade is too dull.\", \"optionality\": \"\"},\n{\"name\": \"3\", \"description\": \"Out of fuel.\", \"optionality\": \"\"}],
+\"subcommands\": [{\n\"name\": \"blow-up\",\n\"usage\": \"test_arg_0 blow-up [--safely]\",
+\"description\": \"explosively separate\",
+\"flags\": [{\"short\": \"\", \"long\": \"--safely\", \"description\": \"blow up bombs safely\", \"arg_name\": \"\", \"optionality\": \"optional\"},
+{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],
+\"positional\": [],
+\"examples\": \"\",
+\"notes\": \"\",
+\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{
+    \"name\": \"grind\",\n\"usage\": \"test_arg_0 grind [--safely]\",\n\"description\": \"make smaller by many small cuts\",
+    \"flags\": [{\"short\": \"\", \"long\": \"--safely\", \"description\": \"wear a visor while grinding\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],
+\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n]\n}
+
+*/
+
+fn assert_help_json_string<T: Help>(args: Vec<&str>, help_str: &str) {
+    let mut command_args = vec!["test_arg_0"];
+    command_args.extend_from_slice(&args);
+    let actual_value = T::help_json_from_args(&command_args)
+        .expect("unexpected error getting help_json_from_args");
+    assert_eq!(help_str, actual_value)
+}

--- a/argh/tests/help_json_tests.rs
+++ b/argh/tests/help_json_tests.rs
@@ -1,11 +1,14 @@
 #![cfg(test)]
-// Copyright (c) 2020 Google LLC All rights reserved.
+// Copyright (c) 2022 Google LLC All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-use std::path::PathBuf;
+use {
+    argh::{FromArgs, Help},
+    std::{fmt::Debug, path::PathBuf},
+};
 
-use {argh:: {FromArgs, Help}, std::fmt::Debug};
+/// Tests that exercise the JSON output for help text.
 
 #[test]
 fn help_json_test_subcommand() {
@@ -602,7 +605,7 @@ fn help_json_test_example() {
         Grind(GrindCommand),
     }
 
-    #[derive(FromArgs,Help, PartialEq, Debug)]
+    #[derive(FromArgs, Help, PartialEq, Debug)]
     #[argh(subcommand, name = "blow-up")]
     /// explosively separate
     struct BlowUp {
@@ -665,33 +668,6 @@ fn help_json_test_example() {
 "###,
     );
 }
-
-/*
-{
-\"name\": \"test_arg_0\",
-\"usage\": \"test_arg_0 [-f] [--really-really-really-long-name-for-pat] -s <scribble> [-v] <command> [<args>]\",
-\"description\": \"Destroy the contents of <file> with a specific \\\"method of destruction\\\".\",
-\"flags\": [{\"short\": \"f\", \"long\": \"--force\", \"description\": \"force, ignore minor errors. This description is so long that it wraps to the next line.\", \"arg_name\": \"\", \"optionality\": \"optional\"},
-{\"short\": \"\", \"long\": \"--really-really-really-long-name-for-pat\", \"description\": \"documentation\", \"arg_name\": \"\", \"optionality\": \"optional\"},
-{\"short\": \"s\", \"long\": \"--scribble\", \"description\": \"write <scribble> repeatedly\", \"arg_name\": \"scribble\", \"optionality\": \"required\"},
-{\"short\": \"v\", \"long\": \"--verbose\", \"description\": \"say more. Defaults to $BLAST_VERBOSE.\", \"arg_name\": \"\", \"optionality\": \"optional\"},
-{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}]
-,\n\"positional\": [],
-\"examples\": \"Scribble 'abc' and then run |grind|.\\n$ test_arg_0 -s 'abc' grind old.txt taxes.cp\",\n\"notes\": \"Use `test_arg_0 help <command>` for details on [<args>] for a subcommand.\",
-\"error_codes\": [{\"name\": \"2\", \"description\": \"The blade is too dull.\", \"optionality\": \"\"},\n{\"name\": \"3\", \"description\": \"Out of fuel.\", \"optionality\": \"\"}],
-\"subcommands\": [{\n\"name\": \"blow-up\",\n\"usage\": \"test_arg_0 blow-up [--safely]\",
-\"description\": \"explosively separate\",
-\"flags\": [{\"short\": \"\", \"long\": \"--safely\", \"description\": \"blow up bombs safely\", \"arg_name\": \"\", \"optionality\": \"optional\"},
-{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],
-\"positional\": [],
-\"examples\": \"\",
-\"notes\": \"\",
-\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{
-    \"name\": \"grind\",\n\"usage\": \"test_arg_0 grind [--safely]\",\n\"description\": \"make smaller by many small cuts\",
-    \"flags\": [{\"short\": \"\", \"long\": \"--safely\", \"description\": \"wear a visor while grinding\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],
-\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n]\n}
-
-*/
 
 fn assert_help_json_string<T: Help>(args: Vec<&str>, help_str: &str) {
     let mut command_args = vec!["test_arg_0"];

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -5,17 +5,20 @@
 use std::fmt::Write;
 use {
     crate::{
+        enum_only_single_field_unnamed_variants,
         errors::Errors,
-        parse_attrs::{Description, FieldKind, TypeAttrs},
-        Optionality, StructField,
+        parse_attrs::{check_enum_type_attrs, Description, FieldKind, TypeAttrs, VariantAttrs},
+        FieldAttrs, Optionality, StructField,
     },
     argh_shared::INDENT,
     proc_macro2::{Span, TokenStream},
-    quote::quote,
+    quote::{quote, quote_spanned, ToTokens},
 };
 
 const SECTION_SEPARATOR: &str = "\n\n";
 
+/// Internal data used to create the HelpPositionalInfo during the
+/// code generation.
 struct PositionalInfo {
     name: String,
     description: String,
@@ -30,7 +33,7 @@ impl PositionalInfo {
             description = desc.content.value().trim().to_owned();
         }
 
-        Self { name, description, optionality: to_help_optional(&field.optionality)}
+        Self { name, description, optionality: to_help_optional(&field.optionality) }
     }
 
     fn as_help_info(&self) -> argh_shared::HelpPositionalInfo {
@@ -41,15 +44,18 @@ impl PositionalInfo {
         }
     }
 }
+
+/// Internal data used to create HelpFlagInfo during the code
+/// generation.
 struct FlagInfo {
     short: Option<char>,
     long: String,
     description: String,
     optionality: argh_shared::HelpOptionality,
-    kind: HelpFieldKind,
+    kind: FlagKind,
 }
 
-enum HelpFieldKind {
+enum FlagKind {
     Switch,
     Option { arg_name: String },
 }
@@ -64,14 +70,14 @@ impl FlagInfo {
             require_description(errors, field.name.span(), &field.attrs.description, "field");
 
         let kind = if field.kind == FieldKind::Switch {
-            HelpFieldKind::Switch
+            FlagKind::Switch
         } else {
             let arg_name = if let Some(arg_name) = &field.attrs.arg_name {
                 arg_name.value()
             } else {
                 long.trim_start_matches("--").to_owned()
             };
-            HelpFieldKind::Option { arg_name }
+            FlagKind::Option { arg_name }
         };
 
         Self { short, long, description, optionality: to_help_optional(&field.optionality), kind }
@@ -79,8 +85,8 @@ impl FlagInfo {
 
     fn as_help_info(&self) -> argh_shared::HelpFlagInfo {
         let kind = match &self.kind {
-            HelpFieldKind::Switch => argh_shared::HelpFieldKind::Switch,
-            HelpFieldKind::Option { arg_name } => {
+            FlagKind::Switch => argh_shared::HelpFieldKind::Switch,
+            FlagKind::Option { arg_name } => {
                 argh_shared::HelpFieldKind::Option { arg_name: arg_name.as_str() }
             }
         };
@@ -95,6 +101,7 @@ impl FlagInfo {
     }
 }
 
+/// Convert optionality to the HelpOptionality type.
 fn to_help_optional(optionality: &Optionality) -> argh_shared::HelpOptionality {
     match optionality {
         // None means it is required
@@ -130,6 +137,7 @@ pub(crate) fn help(
         })
         .collect::<Vec<_>>();
 
+    // Convert the internal PositionalInfo into HelpPositionalInfo which is used as in the generated code.
     let positionals = positionals.iter().map(|o| o.as_help_info()).collect::<Vec<_>>();
 
     let flags = fields
@@ -283,4 +291,276 @@ fn option_description_format(
 
     let info = argh_shared::CommandInfo { name: &name, description };
     argh_shared::write_description(out, &info);
+}
+
+pub(crate) fn impl_derive_help(input: &syn::DeriveInput) -> TokenStream {
+    let errors = &Errors::default();
+    if !input.generics.params.is_empty() {
+        errors.err(
+            &input.generics,
+            "`#![derive(Help)]` cannot be applied to types with generic parameters",
+        );
+    }
+    let type_attrs = &TypeAttrs::parse(errors, input);
+    let mut output_tokens = match &input.data {
+        syn::Data::Struct(ds) => impl_help_from_args_struct(errors, &input.ident, type_attrs, ds),
+        syn::Data::Enum(de) => impl_help_from_args_enum(errors, &input.ident, type_attrs, de),
+        syn::Data::Union(_) => {
+            errors.err(input, "`#[derive(Help)]` cannot be applied to unions");
+            TokenStream::new()
+        }
+    };
+    errors.to_tokens(&mut output_tokens);
+    output_tokens
+}
+
+fn impl_help<'a>(
+    errors: &Errors,
+    type_attrs: &TypeAttrs,
+    fields: &'a [StructField<'a>],
+) -> TokenStream {
+    let mut subcommands_iter =
+        fields.iter().filter(|field| field.kind == FieldKind::SubCommand).fuse();
+
+    let subcommand: Option<&StructField<'_>> = subcommands_iter.next();
+    for dup_subcommand in subcommands_iter {
+        errors.duplicate_attrs("subcommand", subcommand.unwrap().field, dup_subcommand.field);
+    }
+
+    let impl_span = Span::call_site();
+
+    let mut positionals = vec![];
+    let mut flags = vec![];
+
+    for field in fields {
+        let optionality = match field.optionality {
+            Optionality::None => quote! { argh::HelpOptionality::None },
+            Optionality::Defaulted(_) => quote! { argh::HelpOptionality::Optional },
+            Optionality::Optional => quote! { argh::HelpOptionality::Optional },
+            Optionality::Repeating => quote! { argh::HelpOptionality::Repeating },
+        };
+
+        match field.kind {
+            FieldKind::Positional => {
+                let name = field.arg_name();
+
+                let description = if let Some(desc) = &field.attrs.description {
+                    desc.content.value().trim().to_owned()
+                } else {
+                    String::new()
+                };
+
+                positionals.push(quote! {
+                    argh::HelpPositionalInfo {
+                        name: #name,
+                        description: #description,
+                        optionality: #optionality,
+                    }
+                });
+            }
+            FieldKind::Switch | FieldKind::Option => {
+                let short = if let Some(short) = &field.attrs.short {
+                    quote! { Some(#short) }
+                } else {
+                    quote! { None }
+                };
+
+                let long = field.long_name.as_ref().expect("missing long name for option");
+
+                let description = require_description(
+                    errors,
+                    field.name.span(),
+                    &field.attrs.description,
+                    "field",
+                );
+
+                let kind = if field.kind == FieldKind::Switch {
+                    quote! {
+                        argh::HelpFieldKind::Switch
+                    }
+                } else {
+                    let arg_name = if let Some(arg_name) = &field.attrs.arg_name {
+                        quote! { #arg_name }
+                    } else {
+                        let arg_name = long.trim_start_matches("--");
+                        quote! { #arg_name }
+                    };
+
+                    quote! {
+                        argh::HelpFieldKind::Option {
+                            arg_name: #arg_name,
+                        }
+                    }
+                };
+
+                flags.push(quote! {
+                    argh::HelpFlagInfo {
+                        short: #short,
+                        long: #long,
+                        description: #description,
+                        optionality: #optionality,
+                        kind: #kind,
+                    }
+                });
+            }
+            FieldKind::SubCommand => {}
+        }
+    }
+
+    let subcommand = if let Some(subcommand) = subcommand {
+        let subcommand_ty = subcommand.ty_without_wrapper;
+        quote! { Some(<#subcommand_ty as argh::HelpSubCommands>::HELP_INFO) }
+    } else {
+        quote! { None }
+    };
+
+    let description =
+        require_description(errors, Span::call_site(), &type_attrs.description, "type");
+    let examples = type_attrs.examples.iter().map(|e| quote! { #e });
+    let notes = type_attrs.notes.iter().map(|e| quote! { #e });
+
+    let error_codes = type_attrs.error_codes.iter().map(|(code, text)| {
+        quote! { (#code, #text) }
+    });
+
+    quote_spanned! { impl_span =>
+        argh::HelpInfo {
+            description: #description,
+            examples: &[#( #examples, )*],
+            notes: &[#( #notes, )*],
+            positionals: &[#( #positionals, )*],
+            flags: &[#( #flags, )*],
+            subcommand: #subcommand,
+            error_codes: &[#( #error_codes, )*],
+        }
+    }
+}
+
+fn impl_help_from_args_struct(
+    errors: &Errors,
+    name: &syn::Ident,
+    type_attrs: &TypeAttrs,
+    ds: &syn::DataStruct,
+) -> TokenStream {
+    let fields = match &ds.fields {
+        syn::Fields::Named(fields) => fields,
+        syn::Fields::Unnamed(_) => {
+            errors.err(
+                &ds.struct_token,
+                "`#![derive(FromArgs)]` is not currently supported on tuple structs",
+            );
+            return TokenStream::new();
+        }
+        syn::Fields::Unit => {
+            errors.err(&ds.struct_token, "#![derive(FromArgs)]` cannot be applied to unit structs");
+            return TokenStream::new();
+        }
+    };
+
+    let fields: Vec<_> = fields
+        .named
+        .iter()
+        .filter_map(|field| {
+            let attrs = FieldAttrs::parse(errors, field);
+            StructField::new(errors, field, attrs)
+        })
+        .collect();
+
+    let impl_span = Span::call_site();
+
+    let help_info = impl_help(errors, type_attrs, &fields);
+
+    let top_or_sub_cmd_help_impl = top_or_sub_cmd_help_impl(errors, name, type_attrs);
+
+    let trait_impl = quote_spanned! { impl_span =>
+        #[automatically_derived]
+        impl argh::Help for #name {
+            const HELP_INFO: &'static argh::HelpInfo = &#help_info;
+        }
+
+        #top_or_sub_cmd_help_impl
+    };
+
+    trait_impl
+}
+
+fn impl_help_from_args_enum(
+    errors: &Errors,
+    name: &syn::Ident,
+    type_attrs: &TypeAttrs,
+    de: &syn::DataEnum,
+) -> TokenStream {
+    check_enum_type_attrs(errors, type_attrs, &de.enum_token.span);
+
+    // An enum variant like `<name>(<ty>)`
+    struct SubCommandVariant<'a> {
+        ty: &'a syn::Type,
+    }
+
+    let mut dynamic_type_and_variant = None;
+
+    let variants: Vec<SubCommandVariant<'_>> = de
+        .variants
+        .iter()
+        .filter_map(|variant| {
+            let name = &variant.ident;
+            let ty = enum_only_single_field_unnamed_variants(errors, &variant.fields)?;
+            if VariantAttrs::parse(errors, variant).is_dynamic.is_some() {
+                if dynamic_type_and_variant.is_some() {
+                    errors.err(variant, "Only one variant can have the `dynamic` attribute");
+                }
+                dynamic_type_and_variant = Some((ty, name));
+                None
+            } else {
+                Some(SubCommandVariant { ty })
+            }
+        })
+        .collect();
+
+    let variant_ty = variants.iter().map(|x| x.ty).collect::<Vec<_>>();
+
+    let dynamic_commands_help = dynamic_type_and_variant.as_ref().map(|(dynamic_type, _)| {
+        quote! {
+            fn dynamic_commands_help() -> &'static [&'static argh::HelpSubCommandsInfo] {
+                <#dynamic_type as argh::DynamicHelpSubCommand>::commands()
+            }
+        }
+    });
+
+    quote! {
+        impl argh::HelpSubCommands for #name {
+            const HELP_INFO: &'static argh::HelpSubCommandsInfo = &argh::HelpSubCommandsInfo {
+                optional: false,
+                commands: &[#(
+                    <#variant_ty as argh::HelpSubCommand>::HELP_INFO,
+                )*],
+            };
+            #dynamic_commands_help
+        }
+    }
+}
+
+fn top_or_sub_cmd_help_impl(
+    errors: &Errors,
+    name: &syn::Ident,
+    type_attrs: &TypeAttrs,
+) -> TokenStream {
+    if type_attrs.is_subcommand.is_some() {
+        let empty_str = syn::LitStr::new("", Span::call_site());
+        let subcommand_name = type_attrs.name.as_ref().unwrap_or_else(|| {
+            errors.err(name, "`#[argh(name = \"...\")]` attribute is required for subcommands");
+            &empty_str
+        });
+        quote! {
+            #[automatically_derived]
+            impl argh::HelpSubCommand for #name {
+                const HELP_INFO: &'static argh::HelpSubCommandInfo = &argh::HelpSubCommandInfo {
+                    name: #subcommand_name,
+                    info: <#name as argh::Help>::HELP_INFO,
+                };
+            }
+        }
+    } else {
+        quote! {}
+    }
 }

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -16,6 +16,96 @@ use {
 
 const SECTION_SEPARATOR: &str = "\n\n";
 
+struct PositionalInfo {
+    name: String,
+    description: String,
+    optionality: argh_shared::HelpOptionality,
+}
+
+impl PositionalInfo {
+    fn new(field: &StructField) -> Self {
+        let name = field.arg_name();
+        let mut description = String::from("");
+        if let Some(desc) = &field.attrs.description {
+            description = desc.content.value().trim().to_owned();
+        }
+
+        Self { name, description, optionality: to_help_optional(&field.optionality)}
+    }
+
+    fn as_help_info(&self) -> argh_shared::HelpPositionalInfo {
+        argh_shared::HelpPositionalInfo {
+            name: &self.name,
+            description: &self.description,
+            optionality: self.optionality,
+        }
+    }
+}
+struct FlagInfo {
+    short: Option<char>,
+    long: String,
+    description: String,
+    optionality: argh_shared::HelpOptionality,
+    kind: HelpFieldKind,
+}
+
+enum HelpFieldKind {
+    Switch,
+    Option { arg_name: String },
+}
+
+impl FlagInfo {
+    fn new(errors: &Errors, field: &StructField) -> Self {
+        let short = field.attrs.short.as_ref().map(|s| s.value());
+
+        let long = field.long_name.as_ref().expect("missing long name for option").to_owned();
+
+        let description =
+            require_description(errors, field.name.span(), &field.attrs.description, "field");
+
+        let kind = if field.kind == FieldKind::Switch {
+            HelpFieldKind::Switch
+        } else {
+            let arg_name = if let Some(arg_name) = &field.attrs.arg_name {
+                arg_name.value()
+            } else {
+                long.trim_start_matches("--").to_owned()
+            };
+            HelpFieldKind::Option { arg_name }
+        };
+
+        Self { short, long, description, optionality: to_help_optional(&field.optionality), kind }
+    }
+
+    fn as_help_info(&self) -> argh_shared::HelpFlagInfo {
+        let kind = match &self.kind {
+            HelpFieldKind::Switch => argh_shared::HelpFieldKind::Switch,
+            HelpFieldKind::Option { arg_name } => {
+                argh_shared::HelpFieldKind::Option { arg_name: arg_name.as_str() }
+            }
+        };
+
+        argh_shared::HelpFlagInfo {
+            short: self.short,
+            long: &self.long,
+            description: &self.description,
+            optionality: self.optionality,
+            kind,
+        }
+    }
+}
+
+fn to_help_optional(optionality: &Optionality) -> argh_shared::HelpOptionality {
+    match optionality {
+        // None means it is required
+        Optionality::None => argh_shared::HelpOptionality::None,
+        // fields with default values are optional.
+        Optionality::Defaulted(_) => argh_shared::HelpOptionality::Optional,
+        Optionality::Optional => argh_shared::HelpOptionality::Optional,
+        Optionality::Repeating => argh_shared::HelpOptionality::Repeating,
+    }
+}
+
 /// Returns a `TokenStream` generating a `String` help message.
 ///
 /// Note: `fields` entries with `is_subcommand.is_some()` will be ignored
@@ -27,21 +117,38 @@ pub(crate) fn help(
     fields: &[StructField<'_>],
     subcommand: Option<&StructField<'_>>,
 ) -> TokenStream {
-    #![allow(clippy::format_push_string)]
     let mut format_lit = "Usage: {command_name}".to_string();
 
-    let positional = fields.iter().filter(|f| f.kind == FieldKind::Positional);
+    let positionals = fields
+        .iter()
+        .filter_map(|f| {
+            if f.kind == FieldKind::Positional {
+                Some(PositionalInfo::new(f))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let positionals = positionals.iter().map(|o| o.as_help_info()).collect::<Vec<_>>();
+
+    let flags = fields
+        .iter()
+        .filter_map(|f| if f.long_name.is_some() { Some(FlagInfo::new(errors, f)) } else { None })
+        .collect::<Vec<_>>();
+
+    let flags = flags.iter().map(|o| o.as_help_info()).collect::<Vec<_>>();
+
     let mut has_positional = false;
-    for arg in positional.clone() {
+    for arg in &positionals {
         has_positional = true;
         format_lit.push(' ');
-        positional_usage(&mut format_lit, arg);
+        arg.help_usage(&mut format_lit);
     }
 
-    let options = fields.iter().filter(|f| f.long_name.is_some());
-    for option in options.clone() {
+    for flag in &flags {
         format_lit.push(' ');
-        option_usage(&mut format_lit, option);
+        flag.help_usage(&mut format_lit);
     }
 
     if let Some(subcommand) = subcommand {
@@ -64,16 +171,17 @@ pub(crate) fn help(
     if has_positional {
         format_lit.push_str(SECTION_SEPARATOR);
         format_lit.push_str("Positional Arguments:");
-        for arg in positional {
-            positional_description(&mut format_lit, arg);
+        for field in positionals {
+            field.help_description(&mut format_lit);
         }
     }
 
     format_lit.push_str(SECTION_SEPARATOR);
     format_lit.push_str("Options:");
-    for option in options {
-        option_description(errors, &mut format_lit, option);
+    for flag in flags {
+        flag.help_description(&mut format_lit);
     }
+
     // Also include "help"
     option_description_format(&mut format_lit, None, "--help", "display usage information");
 
@@ -138,61 +246,6 @@ fn lits_section(out: &mut String, heading: &str, lits: &[syn::LitStr]) {
     }
 }
 
-/// Add positional arguments like `[<foo>...]` to a help format string.
-fn positional_usage(out: &mut String, field: &StructField<'_>) {
-    if !field.optionality.is_required() {
-        out.push('[');
-    }
-    out.push('<');
-    let name = field.arg_name();
-    out.push_str(&name);
-    if field.optionality == Optionality::Repeating {
-        out.push_str("...");
-    }
-    out.push('>');
-    if !field.optionality.is_required() {
-        out.push(']');
-    }
-}
-
-/// Add options like `[-f <foo>]` to a help format string.
-/// This function must only be called on options (things with `long_name.is_some()`)
-fn option_usage(out: &mut String, field: &StructField<'_>) {
-    // bookend with `[` and `]` if optional
-    if !field.optionality.is_required() {
-        out.push('[');
-    }
-
-    let long_name = field.long_name.as_ref().expect("missing long name for option");
-    if let Some(short) = field.attrs.short.as_ref() {
-        out.push('-');
-        out.push(short.value());
-    } else {
-        out.push_str(long_name);
-    }
-
-    match field.kind {
-        FieldKind::SubCommand | FieldKind::Positional => unreachable!(), // don't have long_name
-        FieldKind::Switch => {}
-        FieldKind::Option => {
-            out.push_str(" <");
-            if let Some(arg_name) = &field.attrs.arg_name {
-                out.push_str(&arg_name.value());
-            } else {
-                out.push_str(long_name.trim_start_matches("--"));
-            }
-            if field.optionality == Optionality::Repeating {
-                out.push_str("...");
-            }
-            out.push('>');
-        }
-    }
-
-    if !field.optionality.is_required() {
-        out.push(']');
-    }
-}
-
 // TODO(cramertj) make it so this is only called at least once per object so
 // as to avoid creating multiple errors.
 pub fn require_description(
@@ -212,35 +265,6 @@ Add a doc comment or an `#[argh(description = \"...\")]` attribute.",
         );
         "".to_string()
     })
-}
-
-/// Describes a positional argument like this:
-///  hello       positional argument description
-fn positional_description(out: &mut String, field: &StructField<'_>) {
-    let field_name = field.arg_name();
-
-    let mut description = String::from("");
-    if let Some(desc) = &field.attrs.description {
-        description = desc.content.value().trim().to_owned();
-    }
-    positional_description_format(out, &field_name, &description)
-}
-
-fn positional_description_format(out: &mut String, name: &str, description: &str) {
-    let info = argh_shared::CommandInfo { name, description };
-    argh_shared::write_description(out, &info);
-}
-
-/// Describes an option like this:
-///  -f, --force       force, ignore minor errors. This description
-///                    is so long that it wraps to the next line.
-fn option_description(errors: &Errors, out: &mut String, field: &StructField<'_>) {
-    let short = field.attrs.short.as_ref().map(|s| s.value());
-    let long_with_leading_dashes = field.long_name.as_ref().expect("missing long name for option");
-    let description =
-        require_description(errors, field.name.span(), &field.attrs.description, "field");
-
-    option_description_format(out, short, long_with_leading_dashes, &description)
 }
 
 fn option_description_format(

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -23,12 +23,43 @@ mod errors;
 mod help;
 mod parse_attrs;
 
+/// Entrypoint for `#[derive(Help)]`.
+#[proc_macro_derive(Help, attributes(argh))]
+pub fn argh_derive_help(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+   let ast = syn::parse_macro_input!(input as syn::DeriveInput);
+   let gen = impl_derive_help(&ast);
+  // let gen = TokenStream::new();
+    gen.into()
+}
+
+
 /// Entrypoint for `#[derive(FromArgs)]`.
 #[proc_macro_derive(FromArgs, attributes(argh))]
 pub fn argh_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse_macro_input!(input as syn::DeriveInput);
     let gen = impl_from_args(&ast);
     gen.into()
+}
+
+fn impl_derive_help(input: &syn::DeriveInput) -> TokenStream {
+    let errors = &Errors::default();
+    if !input.generics.params.is_empty() {
+        errors.err(
+            &input.generics,
+            "`#![derive(Help)]` cannot be applied to types with generic parameters",
+        );
+    }
+    let type_attrs = &TypeAttrs::parse(errors, input);
+    let mut output_tokens = match &input.data {
+        syn::Data::Struct(ds) => impl_help_from_args_struct(errors, &input.ident, type_attrs, ds),
+        syn::Data::Enum(de) => impl_help_from_args_enum(errors, &input.ident, type_attrs, de),
+        syn::Data::Union(_) => {
+            errors.err(input, "`#[derive(Help)]` cannot be applied to unions");
+            TokenStream::new()
+        }
+    };
+    errors.to_tokens(&mut output_tokens);
+    output_tokens
 }
 
 /// Transform the input into a token stream containing any generated implementations,
@@ -202,6 +233,56 @@ impl<'a> StructField<'a> {
     }
 }
 
+fn impl_help_from_args_struct(
+    errors: &Errors,
+    name: &syn::Ident,
+    type_attrs: &TypeAttrs,
+    ds: &syn::DataStruct, 
+) -> TokenStream {
+
+    let fields = match &ds.fields {
+        syn::Fields::Named(fields) => fields,
+        syn::Fields::Unnamed(_) => {
+            errors.err(
+                &ds.struct_token,
+                "`#![derive(FromArgs)]` is not currently supported on tuple structs",
+            );
+            return TokenStream::new();
+        }
+        syn::Fields::Unit => {
+            errors.err(&ds.struct_token, "#![derive(FromArgs)]` cannot be applied to unit structs");
+            return TokenStream::new();
+        }
+    };
+
+    let fields: Vec<_> = fields
+    .named
+    .iter()
+    .filter_map(|field| {
+        let attrs = FieldAttrs::parse(errors, field);
+        StructField::new(errors, field, attrs)
+    })
+    .collect();
+
+    let impl_span = Span::call_site();
+
+    let help_info = impl_help(errors, type_attrs, &fields);
+
+    let top_or_sub_cmd_help_impl = top_or_sub_cmd_help_impl(errors, name, type_attrs);
+
+    let trait_impl = quote_spanned! { impl_span =>
+        #[automatically_derived]
+        impl argh::Help for #name {
+            const HELP_INFO: &'static argh::HelpInfo = &#help_info;
+        }
+
+        #top_or_sub_cmd_help_impl
+    };
+
+    trait_impl
+
+}
+
 /// Implements `FromArgs` and `TopLevelCommand` or `SubCommand` for a `#[derive(FromArgs)]` struct.
 fn impl_from_args_struct(
     errors: &Errors,
@@ -252,11 +333,132 @@ fn impl_from_args_struct(
 
             #redact_arg_values_method
         }
-
         #top_or_sub_cmd_impl
     };
 
     trait_impl
+}
+
+fn impl_help<'a>(
+    errors: &Errors,
+    type_attrs: &TypeAttrs,
+    fields: &'a [StructField<'a>],
+) -> TokenStream {
+    let mut subcommands_iter =
+        fields.iter().filter(|field| field.kind == FieldKind::SubCommand).fuse();
+
+    let subcommand: Option<&StructField<'_>> = subcommands_iter.next();
+    for dup_subcommand in subcommands_iter {
+        errors.duplicate_attrs("subcommand", subcommand.unwrap().field, dup_subcommand.field);
+    }
+
+    let impl_span = Span::call_site();
+
+    let mut positionals = vec![];
+    let mut flags = vec![];
+
+    for field in fields {
+        let optionality = match field.optionality {
+            Optionality::None => quote! { argh::HelpOptionality::None },
+            Optionality::Defaulted(_) => quote! { argh::HelpOptionality::Optional },
+            Optionality::Optional => quote! { argh::HelpOptionality::Optional },
+            Optionality::Repeating => quote! { argh::HelpOptionality::Repeating },
+        };
+
+        match field.kind {
+            FieldKind::Positional => {
+                let name = field.arg_name();
+
+                let description = if let Some(desc) = &field.attrs.description {
+                    desc.content.value().trim().to_owned()
+                } else {
+                    String::new()
+                };
+
+                positionals.push(quote! {
+                    argh::HelpPositionalInfo {
+                        name: #name,
+                        description: #description,
+                        optionality: #optionality,
+                    }
+                });
+            }
+            FieldKind::Switch | FieldKind::Option => {
+                let short = if let Some(short) = &field.attrs.short {
+                    quote! { Some(#short) }
+                } else {
+                    quote! { None }
+                };
+
+                let long = field.long_name.as_ref().expect("missing long name for option");
+
+                let description = help::require_description(
+                    errors,
+                    field.name.span(),
+                    &field.attrs.description,
+                    "field",
+                );
+
+                let kind = if field.kind == FieldKind::Switch {
+                    quote! {
+                        argh::HelpFieldKind::Switch
+                    }
+                } else {
+                    let arg_name = if let Some(arg_name) = &field.attrs.arg_name {
+                        quote! { #arg_name }
+                    } else {
+                        let arg_name = long.trim_start_matches("--");
+                        quote! { #arg_name }
+                    };
+
+                    quote! {
+                        argh::HelpFieldKind::Option {
+                            arg_name: #arg_name,
+                        }
+                    }
+                };
+
+                flags.push(quote! {
+                    argh::HelpFlagInfo {
+                        short: #short,
+                        long: #long,
+                        description: #description,
+                        optionality: #optionality,
+                        kind: #kind,
+                    }
+                });
+            }
+            FieldKind::SubCommand => {}
+        }
+    }
+
+    let subcommand = if let Some(subcommand) = subcommand {
+        let subcommand_ty = subcommand.ty_without_wrapper;
+        quote! { Some(<#subcommand_ty as argh::HelpSubCommands>::HELP_INFO) }
+    } else {
+        quote! { None }
+    };
+
+    let description =
+        help::require_description(errors, Span::call_site(), &type_attrs.description, "type");
+    let examples = type_attrs.examples.iter().map(|e| quote! { #e });
+    let notes = type_attrs.notes.iter().map(|e| quote! { #e });
+
+    let error_codes = type_attrs.error_codes.iter().map(|(code, text)| {
+        quote! { (#code, #text) }
+    });
+
+    quote_spanned! { impl_span =>
+        argh::HelpInfo {
+            description: #description,
+            examples: &[#( #examples, )*],
+            notes: &[#( #notes, )*],
+            positionals: &[#( #positionals, )*],
+            flags: &[#( #flags, )*],
+            subcommand: #subcommand,
+            error_codes: &[#( #error_codes, )*],
+        }
+    }
 }
 
 fn impl_from_args_struct_from_args<'a>(
@@ -539,6 +741,26 @@ fn ensure_unique_names(errors: &Errors, fields: &[StructField<'_>]) {
     }
 }
 
+fn top_or_sub_cmd_help_impl(errors: &Errors, name: &syn::Ident, type_attrs: &TypeAttrs) -> TokenStream {
+    if type_attrs.is_subcommand.is_some() {
+        let empty_str = syn::LitStr::new("", Span::call_site());
+        let subcommand_name = type_attrs.name.as_ref().unwrap_or_else(|| {
+            errors.err(name, "`#[argh(name = \"...\")]` attribute is required for subcommands");
+            &empty_str
+        });
+        quote! {
+            #[automatically_derived]
+            impl argh::HelpSubCommand for #name {
+                const HELP_INFO: &'static argh::HelpSubCommandInfo = &argh::HelpSubCommandInfo {
+                    name: #subcommand_name,
+                    info: <#name as argh::Help>::HELP_INFO,
+                };
+            }
+        }
+    } else {
+        quote! {}
+    }
+}
 /// Implement `argh::TopLevelCommand` or `argh::SubCommand` as appropriate.
 fn top_or_sub_cmd_impl(errors: &Errors, name: &syn::Ident, type_attrs: &TypeAttrs) -> TokenStream {
     let description =
@@ -871,6 +1093,62 @@ fn ty_inner<'a>(wrapper_names: &[&str], ty: &'a syn::Type) -> Option<&'a syn::Ty
         }
     }
     None
+}
+
+fn impl_help_from_args_enum(
+    errors: &Errors,
+    name: &syn::Ident,
+    type_attrs: &TypeAttrs,
+    de: &syn::DataEnum,
+) -> TokenStream {
+    parse_attrs::check_enum_type_attrs(errors, type_attrs, &de.enum_token.span);
+
+        // An enum variant like `<name>(<ty>)`
+        struct SubCommandVariant<'a> {
+            ty: &'a syn::Type,
+        }
+    
+        let mut dynamic_type_and_variant = None;
+    
+        let variants: Vec<SubCommandVariant<'_>> = de
+            .variants
+            .iter()
+            .filter_map(|variant| {
+                let name = &variant.ident;
+                let ty = enum_only_single_field_unnamed_variants(errors, &variant.fields)?;
+                if parse_attrs::VariantAttrs::parse(errors, variant).is_dynamic.is_some() {
+                    if dynamic_type_and_variant.is_some() {
+                        errors.err(variant, "Only one variant can have the `dynamic` attribute");
+                    }
+                    dynamic_type_and_variant = Some((ty, name));
+                    None
+                } else {
+                    Some(SubCommandVariant { ty })
+                }
+            })
+            .collect();
+    
+        let variant_ty = variants.iter().map(|x| x.ty).collect::<Vec<_>>();
+
+        let dynamic_commands_help = dynamic_type_and_variant.as_ref().map(|(dynamic_type, _)| {
+            quote! {
+                fn dynamic_commands_help() -> &'static [&'static argh::HelpSubCommandsInfo] {
+                    <#dynamic_type as argh::DynamicHelpSubCommand>::commands()
+                }
+            }
+        });
+
+    quote! {
+        impl argh::HelpSubCommands for #name {
+            const HELP_INFO: &'static argh::HelpSubCommandsInfo = &argh::HelpSubCommandsInfo {
+                optional: false,
+                commands: &[#(
+                    <#variant_ty as argh::HelpSubCommand>::HELP_INFO,
+                )*],
+            };
+            #dynamic_commands_help
+        }
+    }
 }
 
 /// Implements `FromArgs` and `SubCommands` for a `#![derive(FromArgs)]` enum.

--- a/argh_shared/Cargo.toml
+++ b/argh_shared/Cargo.toml
@@ -7,3 +7,6 @@ license = "BSD-3-Clause"
 description = "Derive-based argument parsing optimized for code size"
 repository = "https://github.com/google/argh"
 readme = "README.md"
+
+[dependencies]
+serde_derive = { version = "1", optional = true }

--- a/argh_shared/src/help.rs
+++ b/argh_shared/src/help.rs
@@ -1,0 +1,442 @@
+// Copyright (c) 2022 Google LLC All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//! TODO
+
+use super::{write_description, CommandInfo, INDENT};
+
+#[cfg(feature = "serde")]
+use serde_derive::{Deserialize, Serialize};
+
+const SECTION_SEPARATOR: &str = "\n\n";
+
+const HELP_FLAG: HelpFlagInfo = HelpFlagInfo {
+    short: None,
+    long: "--help",
+    description: "display usage information",
+    optionality: HelpOptionality::Optional,
+    kind: HelpFieldKind::Switch,
+};
+
+/// TODO
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HelpInfo<'a> {
+    /// TODO
+    pub description: &'a str,
+    /// TODO
+    pub examples: &'a [&'a str],
+    /// TODO
+    pub notes: &'a [&'a str],
+    /// TODO
+    pub flags: &'a [HelpFlagInfo<'a>],
+    /// TODO
+    pub positionals: &'a [HelpPositionalInfo<'a>],
+    /// TODO
+    pub subcommand: Option<&'a HelpSubCommandsInfo<'a>>,
+    /// TODO
+    pub error_codes: &'a [(isize, &'a str)],
+}
+
+fn help_section(out: &mut String, command_name: &str, heading: &str, sections: &[&str]) {
+    if !sections.is_empty() {
+        out.push_str(SECTION_SEPARATOR);
+        for section in sections {
+            let section = section.replace("{command_name}", command_name);
+
+            out.push_str(heading);
+            for line in section.split('\n') {
+                out.push('\n');
+                out.push_str(INDENT);
+                out.push_str(line);
+            }
+        }
+    }
+}
+
+impl<'a> HelpInfo<'a> {
+    /// TODO
+    pub fn help(&self, command_name: &[&str]) -> String {
+        let command_name = command_name.join(" ");
+        let mut out = format!("Usage: {}", command_name);
+
+        for positional in self.positionals {
+            out.push(' ');
+            positional.help_usage(&mut out);
+        }
+
+        for flag in self.flags {
+            out.push(' ');
+            flag.help_usage(&mut out);
+        }
+
+        if let Some(subcommand) = &self.subcommand {
+            out.push(' ');
+            if subcommand.optional {
+                out.push('[');
+            }
+            out.push_str("<command>");
+            if subcommand.optional {
+                out.push(']');
+            }
+            out.push_str(" [<args>]");
+        }
+
+        out.push_str(SECTION_SEPARATOR);
+
+        out.push_str(self.description);
+
+        if !self.positionals.is_empty() {
+            out.push_str(SECTION_SEPARATOR);
+            out.push_str("Positional Arguments:");
+            for positional in self.positionals {
+                positional.help_description(&mut out);
+            }
+        }
+
+        out.push_str(SECTION_SEPARATOR);
+        out.push_str("Options:");
+        for flag in self.flags {
+            flag.help_description(&mut out);
+        }
+
+        // Also include "help"
+        HELP_FLAG.help_description(&mut out);
+
+        if let Some(subcommand) = &self.subcommand {
+            out.push_str(SECTION_SEPARATOR);
+            out.push_str("Commands:");
+            for cmd in subcommand.commands {
+                let info = CommandInfo { name: cmd.name, description: cmd.info.description };
+                write_description(&mut out, &info);
+            }
+        }
+
+        help_section(&mut out, &command_name, "Examples:", self.examples);
+
+        help_section(&mut out, &command_name, "Notes:", self.notes);
+
+        if !self.error_codes.is_empty() {
+            out.push_str(SECTION_SEPARATOR);
+            out.push_str("Error codes:");
+            write_error_codes(&mut out, self.error_codes);
+        }
+
+        out.push('\n');
+
+        out
+    }
+
+    /// Returns a JSON encoded string of the usage information. This is intended to
+    /// create a "machine readable" version of the help text to enable reference
+    /// documentation generation.
+    pub fn help_json_from_args(&self, command_name_arr: &[&str]) -> String {
+        let command_name = command_name_arr.join(" ");
+
+        let mut out = format!("{{\n\"name\": \"{}\"", command_name_arr.last().unwrap_or(&"<unknown>"));
+        out.push_str(format!(",\n\"usage\": \"{}\"", self.usage_string(&command_name)).as_str());
+        out.push_str(format!(",\n\"description\": \"{}\"", escape_json(&self.description.replace("{command_name}", &command_name))).as_str());
+
+     
+        out.push_str(",\n\"flags\": [");
+        let mut first = true;
+        for flag in self.flags {
+            let short_flag = match flag.short {
+                Some(ch) => format!("{}",ch),
+                None => String::from("")
+            };
+            let arg_name = match flag.kind {
+                HelpFieldKind::Option { arg_name } => arg_name,
+                _ => ""
+            };
+            let optionality = match flag.optionality {
+                HelpOptionality::Optional => "optional",
+                HelpOptionality::Repeating => "repeating",
+                HelpOptionality::None => "required"
+            };
+
+            if ! first {
+                out.push_str(",\n");
+            }
+            first = false;
+            out.push_str(format!("{{\"short\": \"{}\"",short_flag).as_str());
+            out.push_str(format!(", \"long\": \"{}\"",flag.long).as_str());
+            out.push_str(format!(", \"description\": \"{}\"", escape_json(flag.description)).as_str());
+            out.push_str(format!(", \"arg_name\": \"{}\"",arg_name).as_str());
+            out.push_str(format!(", \"optionality\": \"{}\"}}",optionality).as_str());
+
+        }
+        //Help flag is implicit
+        if ! first {
+            out.push_str(",\n");
+        }
+        out.push_str("{\"short\": \"\"");
+        out.push_str(", \"long\": \"--help\"");
+        out.push_str(format!(", \"description\": \"{}\"",HELP_FLAG.description).as_str());
+        out.push_str(", \"arg_name\": \"\"");
+        out.push_str(", \"optionality\": \"optional\"}");
+
+        out.push(']');
+
+        out.push_str(",\n\"positional\": [");
+        first = true;
+        for positional in self.positionals {
+            let optionality = match positional.optionality {
+                HelpOptionality::Optional => "optional",
+                HelpOptionality::Repeating => "repeating",
+                HelpOptionality::None => "required"
+            };
+            if ! first {
+                out.push_str(",\n");
+            }
+            first = false;
+            out.push_str(format!("{{\"name\": \"{}\"", positional.name).as_str());
+            out.push_str(format!(", \"description\": \"{}\"", escape_json(positional.description)).as_str());
+            out.push_str(format!(", \"optionality\": \"{}\"",optionality).as_str());
+            out.push('}');
+        }
+        out.push(']');
+        
+        out.push_str(format!(",\n\"examples\": \"{}\"", escape_json(&self.examples.join("\n").replace("{command_name}", &command_name))).as_str());
+        out.push_str(format!(",\n\"notes\": \"{}\"", escape_json(&self.notes.join("\n").replace("{command_name}", &command_name))).as_str());
+
+        out.push_str(",\n\"error_codes\": [");
+        first = true;
+        for (code, description) in self.error_codes {
+            if ! first {
+                out.push_str(",\n");
+            }
+            first = false;
+           out.push_str(format!("{{\"name\": \"{}\", \"description\": \"{}\"}}",code, escape_json(description)).as_str());
+        }
+        out.push(']');
+
+        if let Some(subcommands) = self.subcommand {
+            first = true;
+
+        out.push_str(",\n\"subcommands\": [");
+            for sub in subcommands.commands {
+                if ! first {
+                    out.push_str(",\n");
+                }
+                first = false;
+                let sub_command_name =  [command_name_arr, &[sub.name]].concat();
+                out.push_str(sub.info.help_json_from_args(&sub_command_name).as_str());
+            }
+            out.push(']');
+        } else {
+            out.push_str(",\n\"subcommands\": []");
+        }
+
+        out.push_str("\n}\n");
+        out
+    }
+
+
+    /*
+  left: `"{\n\"name\": \"test_arg_0\",\n\"usage\": \"test_arg_0 [--verbose] <command> [<args>]\",\n\"description\": \"Top level command with \\\"subcommands\\\".\",\n\"flags\": [{\"short\": \"\", \"long\": \"--verbose\", \"description\": \"show verbose output\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": [{\n\"name\": \"one\",\n\"usage\": \"test_arg_0 one <root> <trunk> [<leaves>]\",\n\"description\": \"Command1 args are used for Command1.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [{\"name\": \"root\", \"description\": \"the \\\"root\\\" position.\", \"optionality\": \"required\"},\n{\"name\": \"trunk\", \"description\": \"trunk value\", \"optionality\": \"required\"},\n{\"name\": \"leaves\", \"description\": \"leaves. There can be zero leaves, defaults to hello.\", \"optionality\": \"optional\"}],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{\n\"name\": \"two\",\n\"usage\": \"test_arg_0 two [--power] --required <required> [-s <speed>] [--link <url...>]\",\n\"description\": \"Command2 args are used for Command2.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--power\", \"description\": \"should the power be on. \\\"Quoted value\\\" should work too.\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--required\", \"description\": \"option that is required because of no default and not Option<>.\", \"arg_name\": \"required_flag\", \"optionality\": \"required\"},\n{\"short\": \"s\", \"long\": \"--speed\", \"description\": \"optional speed if not specified it is None.\", \"arg_name\": \"speed\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--link\", \"description\": \"repeatable option.\", \"arg_name\": \"url\", \"optionality\": \"repeating\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{\n\"name\": \"three\",\n\"usage\": \"test_arg_0 three\",\n\"description\": \"Command3 args are used for Command3 which has no options or arguments.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n]\n}\n"`,
+ right: `"{\n\"name\": \"test_arg_0\",\n\"usage\": \"test_arg_0 [--verbose] <command> [<args>]\",\n\"description\": \"Top level command with \\\"subcommands\\\".\",\n\"flags\": [{\"short\": \"\", \"long\": \"--verbose\", \"description\": \"show verbose output\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": [{\n\"name\": \"one\",\n\"usage\": \"test_arg_0 one <root> <trunk> [<leaves>]\",\n\"description\": \"Command1 args are used for Command1.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [{\"name\": \"root\", \"description\": \"the \\\"root\\\" position.\", \"optionality\": \"required\"},\n{\"name\": \"trunk\", \"description\": \"trunk value\", \"optionality\": \"required\"},\n{\"name\": \"leaves\", \"description\": \"leaves. There can be zero leaves, defaults to hello.\", \"optionality\": \"optional\"}],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{\n\"name\": \"two\",\n\"usage\": \"test_arg_0 two [--power] --required <required> [-s <speed>] [--link <url...>]\",\n\"description\": \"Command2 args are used for Command2.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--power\", \"description\": \"should the power be on. \\\"Quoted value\\\" should work too.\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--required\", \"description\": \"option that is required because of no default and not Option<>.\", \"arg_name\": \"required\", \"optionality\": \"required\"},\n{\"short\": \"s\", \"long\": \"--speed\", \"description\": \"optional speed if not specified it is None.\", \"arg_name\": \"speed\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--link\", \"description\": \"repeatable option.\", \"arg_name\": \"url\", \"optionality\": \"repeating\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{\n\"name\": \"three\",\n\"usage\": \"test_arg_0 three\",\n\"description\": \"Command3 args are used for Command3 which has no options or arguments.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n]\n}\n"`',
+
+ */
+
+    fn usage_string(&self, command_name: &String) -> String {
+        let mut out =  command_name.to_string();
+
+        for positional in self.positionals {
+            out.push(' ');
+            positional.help_usage(&mut out);
+        }
+
+        for flag in self.flags {
+            out.push(' ');
+            flag.help_usage(&mut out);
+        }
+
+        if let Some(subcommand) = &self.subcommand {
+            out.push(' ');
+            if subcommand.optional {
+                out.push('[');
+            }
+            out.push_str("<command>");
+            if subcommand.optional {
+                out.push(']');
+            }
+            out.push_str(" [<args>]");
+        }
+
+        out
+    }
+}
+
+fn escape_json(value: &str) -> String {
+    value.replace('\n', r#"\n"#).replace('"', r#"\""#)
+}
+
+fn write_error_codes(out: &mut String, error_codes: &[(isize, &str)]) {
+    for (code, text) in error_codes {
+        out.push('\n');
+        out.push_str(INDENT);
+        out.push_str(&format!("{} {}", code, text));
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HelpSubCommandsInfo<'a> {
+    /// TODO
+    pub optional: bool,
+    /// TODO
+    pub commands: &'a [&'a HelpSubCommandInfo<'a>],
+}
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HelpSubCommandInfo<'a> {
+    /// TODO
+    pub name: &'a str,
+    /// TODO
+    pub info: &'a HelpInfo<'a>,
+}
+
+/// TODO
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum HelpOptionality {
+    /// TODO
+    None,
+    /// TODO
+    Optional,
+    /// TODO
+    Repeating,
+}
+
+impl HelpOptionality {
+    /// TODO
+    fn is_required(&self) -> bool {
+        matches!(self, HelpOptionality::None)
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HelpPositionalInfo<'a> {
+    /// TODO
+    pub name: &'a str,
+    /// TODO
+    pub description: &'a str,
+    /// TODO
+    pub optionality: HelpOptionality
+}
+
+impl<'a> HelpPositionalInfo<'a> {
+    /// Add positional arguments like `[<foo>...]` to a help format string.
+    pub fn help_usage(&self, out: &mut String) {
+        if !self.optionality.is_required() {
+            out.push('[');
+        }
+
+        out.push('<');
+        out.push_str(self.name);
+
+        if self.optionality == HelpOptionality::Repeating {
+            out.push_str("...");
+        }
+
+        out.push('>');
+
+        if !self.optionality.is_required() {
+            out.push(']');
+        }
+    }
+
+    /// Describes a positional argument like this:
+    ///  hello       positional argument description
+    pub fn help_description(&self, out: &mut String) {
+        let info = CommandInfo { name: self.name, description: self.description };
+        write_description(out, &info);
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HelpFlagInfo<'a> {
+    /// TODO
+    pub short: Option<char>,
+    /// TODO
+    pub long: &'a str,
+    /// TODO
+    pub description: &'a str,
+    /// TODO
+    pub optionality: HelpOptionality,
+    /// TODO
+    pub kind: HelpFieldKind<'a>,
+}
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum HelpFieldKind<'a> {
+    /// TODO
+    Switch,
+    /// TODO
+    Option {
+        /// TODO
+        arg_name: &'a str,
+    },
+}
+
+impl<'a> HelpFlagInfo<'a> {
+    /// Add options like `[-f <foo>]` to a help format string.
+    /// This function must only be called on options (things with `long_name.is_some()`)
+    pub fn help_usage(&self, out: &mut String) {
+        if !self.optionality.is_required() {
+            out.push('[');
+        }
+
+        if let Some(short) = self.short {
+            out.push('-');
+            out.push(short);
+        } else {
+            out.push_str(self.long);
+        }
+
+        match self.kind {
+            HelpFieldKind::Switch => {}
+            HelpFieldKind::Option { arg_name } => {
+                out.push_str(" <");
+                out.push_str(arg_name);
+
+                if self.optionality == HelpOptionality::Repeating {
+                    out.push_str("...");
+                }
+
+                out.push('>');
+            }
+        }
+
+        if !self.optionality.is_required() {
+            out.push(']');
+        }
+    }
+
+    /// Describes an option like this:
+    ///  -f, --force       force, ignore minor errors. This description
+    ///                    is so long that it wraps to the next line.
+    pub fn help_description(&self, out: &mut String) {
+        let mut name = String::new();
+        if let Some(short) = self.short {
+            name.push('-');
+            name.push(short);
+            name.push_str(", ");
+        }
+        name.push_str(self.long);
+
+        let info = CommandInfo { name: &name, description: self.description };
+        write_description(out, &info);
+    }
+}

--- a/argh_shared/src/help.rs
+++ b/argh_shared/src/help.rs
@@ -134,46 +134,53 @@ impl<'a> HelpInfo<'a> {
     pub fn help_json_from_args(&self, command_name_arr: &[&str]) -> String {
         let command_name = command_name_arr.join(" ");
 
-        let mut out = format!("{{\n\"name\": \"{}\"", command_name_arr.last().unwrap_or(&"<unknown>"));
+        let mut out =
+            format!("{{\n\"name\": \"{}\"", command_name_arr.last().unwrap_or(&"<unknown>"));
         out.push_str(format!(",\n\"usage\": \"{}\"", self.usage_string(&command_name)).as_str());
-        out.push_str(format!(",\n\"description\": \"{}\"", escape_json(&self.description.replace("{command_name}", &command_name))).as_str());
+        out.push_str(
+            format!(
+                ",\n\"description\": \"{}\"",
+                escape_json(&self.description.replace("{command_name}", &command_name))
+            )
+            .as_str(),
+        );
 
-     
         out.push_str(",\n\"flags\": [");
         let mut first = true;
         for flag in self.flags {
             let short_flag = match flag.short {
-                Some(ch) => format!("{}",ch),
-                None => String::from("")
+                Some(ch) => format!("{}", ch),
+                None => String::from(""),
             };
             let arg_name = match flag.kind {
                 HelpFieldKind::Option { arg_name } => arg_name,
-                _ => ""
+                _ => "",
             };
             let optionality = match flag.optionality {
                 HelpOptionality::Optional => "optional",
                 HelpOptionality::Repeating => "repeating",
-                HelpOptionality::None => "required"
+                HelpOptionality::None => "required",
             };
 
-            if ! first {
+            if !first {
                 out.push_str(",\n");
             }
             first = false;
-            out.push_str(format!("{{\"short\": \"{}\"",short_flag).as_str());
-            out.push_str(format!(", \"long\": \"{}\"",flag.long).as_str());
-            out.push_str(format!(", \"description\": \"{}\"", escape_json(flag.description)).as_str());
-            out.push_str(format!(", \"arg_name\": \"{}\"",arg_name).as_str());
-            out.push_str(format!(", \"optionality\": \"{}\"}}",optionality).as_str());
-
+            out.push_str(format!("{{\"short\": \"{}\"", short_flag).as_str());
+            out.push_str(format!(", \"long\": \"{}\"", flag.long).as_str());
+            out.push_str(
+                format!(", \"description\": \"{}\"", escape_json(flag.description)).as_str(),
+            );
+            out.push_str(format!(", \"arg_name\": \"{}\"", arg_name).as_str());
+            out.push_str(format!(", \"optionality\": \"{}\"}}", optionality).as_str());
         }
         //Help flag is implicit
-        if ! first {
+        if !first {
             out.push_str(",\n");
         }
         out.push_str("{\"short\": \"\"");
         out.push_str(", \"long\": \"--help\"");
-        out.push_str(format!(", \"description\": \"{}\"",HELP_FLAG.description).as_str());
+        out.push_str(format!(", \"description\": \"{}\"", HELP_FLAG.description).as_str());
         out.push_str(", \"arg_name\": \"\"");
         out.push_str(", \"optionality\": \"optional\"}");
 
@@ -185,43 +192,64 @@ impl<'a> HelpInfo<'a> {
             let optionality = match positional.optionality {
                 HelpOptionality::Optional => "optional",
                 HelpOptionality::Repeating => "repeating",
-                HelpOptionality::None => "required"
+                HelpOptionality::None => "required",
             };
-            if ! first {
+            if !first {
                 out.push_str(",\n");
             }
             first = false;
             out.push_str(format!("{{\"name\": \"{}\"", positional.name).as_str());
-            out.push_str(format!(", \"description\": \"{}\"", escape_json(positional.description)).as_str());
-            out.push_str(format!(", \"optionality\": \"{}\"",optionality).as_str());
+            out.push_str(
+                format!(", \"description\": \"{}\"", escape_json(positional.description)).as_str(),
+            );
+            out.push_str(format!(", \"optionality\": \"{}\"", optionality).as_str());
             out.push('}');
         }
         out.push(']');
-        
-        out.push_str(format!(",\n\"examples\": \"{}\"", escape_json(&self.examples.join("\n").replace("{command_name}", &command_name))).as_str());
-        out.push_str(format!(",\n\"notes\": \"{}\"", escape_json(&self.notes.join("\n").replace("{command_name}", &command_name))).as_str());
+
+        out.push_str(
+            format!(
+                ",\n\"examples\": \"{}\"",
+                escape_json(&self.examples.join("\n").replace("{command_name}", &command_name))
+            )
+            .as_str(),
+        );
+        out.push_str(
+            format!(
+                ",\n\"notes\": \"{}\"",
+                escape_json(&self.notes.join("\n").replace("{command_name}", &command_name))
+            )
+            .as_str(),
+        );
 
         out.push_str(",\n\"error_codes\": [");
         first = true;
         for (code, description) in self.error_codes {
-            if ! first {
+            if !first {
                 out.push_str(",\n");
             }
             first = false;
-           out.push_str(format!("{{\"name\": \"{}\", \"description\": \"{}\"}}",code, escape_json(description)).as_str());
+            out.push_str(
+                format!(
+                    "{{\"name\": \"{}\", \"description\": \"{}\"}}",
+                    code,
+                    escape_json(description)
+                )
+                .as_str(),
+            );
         }
         out.push(']');
 
         if let Some(subcommands) = self.subcommand {
             first = true;
 
-        out.push_str(",\n\"subcommands\": [");
+            out.push_str(",\n\"subcommands\": [");
             for sub in subcommands.commands {
-                if ! first {
+                if !first {
                     out.push_str(",\n");
                 }
                 first = false;
-                let sub_command_name =  [command_name_arr, &[sub.name]].concat();
+                let sub_command_name = [command_name_arr, &[sub.name]].concat();
                 out.push_str(sub.info.help_json_from_args(&sub_command_name).as_str());
             }
             out.push(']');
@@ -233,15 +261,8 @@ impl<'a> HelpInfo<'a> {
         out
     }
 
-
-    /*
-  left: `"{\n\"name\": \"test_arg_0\",\n\"usage\": \"test_arg_0 [--verbose] <command> [<args>]\",\n\"description\": \"Top level command with \\\"subcommands\\\".\",\n\"flags\": [{\"short\": \"\", \"long\": \"--verbose\", \"description\": \"show verbose output\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": [{\n\"name\": \"one\",\n\"usage\": \"test_arg_0 one <root> <trunk> [<leaves>]\",\n\"description\": \"Command1 args are used for Command1.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [{\"name\": \"root\", \"description\": \"the \\\"root\\\" position.\", \"optionality\": \"required\"},\n{\"name\": \"trunk\", \"description\": \"trunk value\", \"optionality\": \"required\"},\n{\"name\": \"leaves\", \"description\": \"leaves. There can be zero leaves, defaults to hello.\", \"optionality\": \"optional\"}],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{\n\"name\": \"two\",\n\"usage\": \"test_arg_0 two [--power] --required <required> [-s <speed>] [--link <url...>]\",\n\"description\": \"Command2 args are used for Command2.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--power\", \"description\": \"should the power be on. \\\"Quoted value\\\" should work too.\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--required\", \"description\": \"option that is required because of no default and not Option<>.\", \"arg_name\": \"required_flag\", \"optionality\": \"required\"},\n{\"short\": \"s\", \"long\": \"--speed\", \"description\": \"optional speed if not specified it is None.\", \"arg_name\": \"speed\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--link\", \"description\": \"repeatable option.\", \"arg_name\": \"url\", \"optionality\": \"repeating\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{\n\"name\": \"three\",\n\"usage\": \"test_arg_0 three\",\n\"description\": \"Command3 args are used for Command3 which has no options or arguments.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n]\n}\n"`,
- right: `"{\n\"name\": \"test_arg_0\",\n\"usage\": \"test_arg_0 [--verbose] <command> [<args>]\",\n\"description\": \"Top level command with \\\"subcommands\\\".\",\n\"flags\": [{\"short\": \"\", \"long\": \"--verbose\", \"description\": \"show verbose output\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": [{\n\"name\": \"one\",\n\"usage\": \"test_arg_0 one <root> <trunk> [<leaves>]\",\n\"description\": \"Command1 args are used for Command1.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [{\"name\": \"root\", \"description\": \"the \\\"root\\\" position.\", \"optionality\": \"required\"},\n{\"name\": \"trunk\", \"description\": \"trunk value\", \"optionality\": \"required\"},\n{\"name\": \"leaves\", \"description\": \"leaves. There can be zero leaves, defaults to hello.\", \"optionality\": \"optional\"}],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{\n\"name\": \"two\",\n\"usage\": \"test_arg_0 two [--power] --required <required> [-s <speed>] [--link <url...>]\",\n\"description\": \"Command2 args are used for Command2.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--power\", \"description\": \"should the power be on. \\\"Quoted value\\\" should work too.\", \"arg_name\": \"\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--required\", \"description\": \"option that is required because of no default and not Option<>.\", \"arg_name\": \"required\", \"optionality\": \"required\"},\n{\"short\": \"s\", \"long\": \"--speed\", \"description\": \"optional speed if not specified it is None.\", \"arg_name\": \"speed\", \"optionality\": \"optional\"},\n{\"short\": \"\", \"long\": \"--link\", \"description\": \"repeatable option.\", \"arg_name\": \"url\", \"optionality\": \"repeating\"},\n{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n,\n{\n\"name\": \"three\",\n\"usage\": \"test_arg_0 three\",\n\"description\": \"Command3 args are used for Command3 which has no options or arguments.\",\n\"flags\": [{\"short\": \"\", \"long\": \"--help\", \"description\": \"display usage information\", \"arg_name\": \"\", \"optionality\": \"optional\"}],\n\"positional\": [],\n\"examples\": \"\",\n\"notes\": \"\",\n\"error_codes\": [],\n\"subcommands\": []\n}\n]\n}\n"`',
-
- */
-
     fn usage_string(&self, command_name: &String) -> String {
-        let mut out =  command_name.to_string();
+        let mut out = command_name.to_string();
 
         for positional in self.positionals {
             out.push(' ');
@@ -329,7 +350,7 @@ pub struct HelpPositionalInfo<'a> {
     /// TODO
     pub description: &'a str,
     /// TODO
-    pub optionality: HelpOptionality
+    pub optionality: HelpOptionality,
 }
 
 impl<'a> HelpPositionalInfo<'a> {

--- a/argh_shared/src/lib.rs
+++ b/argh_shared/src/lib.rs
@@ -12,31 +12,6 @@ pub use crate::help::{
     HelpFieldKind, HelpFlagInfo, HelpInfo, HelpOptionality, HelpPositionalInfo, HelpSubCommandInfo,
     HelpSubCommandsInfo,
 };
-
-/// Information to display to the user about why a `FromArgs` construction exited early.
-///
-/// This can occur due to either failed parsing or a flag like `--help`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EarlyExit {
-    /// The output to display to the user of the commandline tool.
-    pub output: String,
-    /// Status of argument parsing.
-    ///
-    /// `Ok` if the command was parsed successfully and the early exit is due
-    /// to a flag like `--help` causing early exit with output.
-    ///
-    /// `Err` if the arguments were not successfully parsed.
-    // TODO replace with std::process::ExitCode when stable.
-    pub status: Result<(), ()>,
-}
-
-impl From<String> for EarlyExit {
-    fn from(err_msg: String) -> Self {
-        Self { output: err_msg, status: Err(()) }
-    }
-}
-
-
 /// Information about a particular command used for output.
 pub struct CommandInfo<'a> {
     /// The name of the command.

--- a/argh_shared/src/lib.rs
+++ b/argh_shared/src/lib.rs
@@ -6,6 +6,37 @@
 //!
 //! This library is intended only for internal use by these two crates.
 
+mod help;
+
+pub use crate::help::{
+    HelpFieldKind, HelpFlagInfo, HelpInfo, HelpOptionality, HelpPositionalInfo, HelpSubCommandInfo,
+    HelpSubCommandsInfo,
+};
+
+/// Information to display to the user about why a `FromArgs` construction exited early.
+///
+/// This can occur due to either failed parsing or a flag like `--help`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EarlyExit {
+    /// The output to display to the user of the commandline tool.
+    pub output: String,
+    /// Status of argument parsing.
+    ///
+    /// `Ok` if the command was parsed successfully and the early exit is due
+    /// to a flag like `--help` causing early exit with output.
+    ///
+    /// `Err` if the arguments were not successfully parsed.
+    // TODO replace with std::process::ExitCode when stable.
+    pub status: Result<(), ()>,
+}
+
+impl From<String> for EarlyExit {
+    fn from(err_msg: String) -> Self {
+        Self { output: err_msg, status: Err(()) }
+    }
+}
+
+
 /// Information about a particular command used for output.
 pub struct CommandInfo<'a> {
     /// The name of the command.
@@ -77,4 +108,9 @@ fn new_line(current_line: &mut String, out: &mut String) {
     out.push('\n');
     out.push_str(current_line);
     current_line.truncate(0);
+}
+
+/// Extract the base cmd from a path
+pub fn cmd<'a>(default: &'a str, path: &'a str) -> &'a str {
+    std::path::Path::new(path).file_name().and_then(|s| s.to_str()).unwrap_or(default)
 }


### PR DESCRIPTION
This is a refactor that requires all structs that implement FromArgs to also derive the argh::Help trait if JSON encoded help is needed.

Added tests, still working on testing in an application.