### PR TITLE
Deps: update `heck` to `0.4`

### DIFF
--- a/argh_derive/Cargo.toml
+++ b/argh_derive/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-heck = "0.3.1"
+heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -184,7 +184,10 @@ impl<'a> StructField<'a> {
                     .long
                     .as_ref()
                     .map(syn::LitStr::value)
-                    .unwrap_or_else(|| heck::KebabCase::to_kebab_case(&*name.to_string()));
+                    .unwrap_or_else(|| {
+                        use heck::ToKebabCase;
+                        name.to_string().to_kebab_case()
+                    });
                 if long_name == "help" {
                     errors.err(field, "Custom `--help` flags are not supported.");
                 }

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -13,6 +13,7 @@ use {
         errors::Errors,
         parse_attrs::{FieldAttrs, FieldKind, TypeAttrs},
     },
+    heck::ToKebabCase,
     proc_macro2::{Span, TokenStream},
     quote::{quote, quote_spanned, ToTokens},
     std::{collections::HashMap, str::FromStr},
@@ -184,10 +185,7 @@ impl<'a> StructField<'a> {
                     .long
                     .as_ref()
                     .map(syn::LitStr::value)
-                    .unwrap_or_else(|| {
-                        use heck::ToKebabCase;
-                        name.to_string().to_kebab_case()
-                    });
+                    .unwrap_or_else(|| name.to_string().to_kebab_case());
                 if long_name == "help" {
                     errors.err(field, "Custom `--help` flags are not supported.");
                 }


### PR DESCRIPTION
A small PR that simply bumps `heck` to `0.4`, which was [released half a year ago](https://github.com/withoutboats/heck/blob/master/CHANGELOG.md#040). Thanks! 👍