### PR TITLE
Support generic structs and enums in derive(FromArgs)

### DIFF
--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -810,7 +810,7 @@ pub fn parse_struct_args(
     let mut positional_index = 0;
     let mut options_ended = false;
 
-    'parse_args: while let Some(&next_arg) = remaining_args.get(0) {
+    'parse_args: while let Some(&next_arg) = remaining_args.first() {
         remaining_args = &remaining_args[1..];
         if (next_arg == "--help" || next_arg == "help") && !options_ended {
             help = true;
@@ -878,7 +878,7 @@ impl<'a> ParseStructOptions<'a> {
             ParseStructOption::Flag(ref mut b) => b.set_flag(arg),
             ParseStructOption::Value(ref mut pvs) => {
                 let value = remaining_args
-                    .get(0)
+                    .first()
                     .ok_or_else(|| ["No value provided for option '", arg, "'.\n"].concat())?;
                 *remaining_args = &remaining_args[1..];
                 pvs.fill_slot(arg, value).map_err(|s| {
@@ -977,6 +977,7 @@ pub struct ParseStructSubCommand<'a> {
     pub dynamic_subcommands: &'a [&'static CommandInfo],
 
     // The function to parse the subcommand arguments.
+    #[allow(clippy::type_complexity)]
     pub parse_func: &'a mut dyn FnMut(&[&str], &[&str]) -> Result<(), EarlyExit>,
 }
 

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -128,7 +128,7 @@ fn dynamic_subcommand_example() {
             let description = Self::commands().iter().find(|x| x.name == command_name)?.description;
             if args.len() > 1 {
                 Some(Err(argh::EarlyExit::from("Too many arguments".to_owned())))
-            } else if let Some(arg) = args.get(0) {
+            } else if let Some(arg) = args.first() {
                 Some(Ok(DynamicSubCommandImpl { got: format!("{} got {:?}", description, arg) }))
             } else {
                 Some(Err(argh::EarlyExit::from("Not enough arguments".to_owned())))
@@ -957,7 +957,7 @@ Options:
                 None
             } else if args.len() > 1 {
                 Some(Err(argh::EarlyExit::from("Too many arguments".to_owned())))
-            } else if let Some(arg) = args.get(0) {
+            } else if let Some(arg) = args.first() {
                 Some(Ok(HelpExamplePlugin { got: format!("plugin got {:?}", arg) }))
             } else {
                 Some(Ok(HelpExamplePlugin { got: "plugin got no argument".to_owned() }))

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -36,6 +36,34 @@ fn basic_example() {
 }
 
 #[test]
+fn generic_example() {
+    use std::fmt::Display;
+    use std::str::FromStr;
+
+    #[derive(FromArgs, PartialEq, Debug)]
+    /// Reach new heights.
+    struct GoUp<S: FromStr>
+    where
+        <S as FromStr>::Err: Display,
+    {
+        /// whether or not to jump
+        #[argh(switch, short = 'j')]
+        jump: bool,
+
+        /// how high to go
+        #[argh(option)]
+        height: usize,
+
+        /// an optional nickname for the pilot
+        #[argh(option)]
+        pilot_nickname: Option<S>,
+    }
+
+    let up = GoUp::<String>::from_args(&["cmdname"], &["--height", "5"]).expect("failed go_up");
+    assert_eq!(up, GoUp::<String> { jump: false, height: 5, pilot_nickname: None });
+}
+
+#[test]
 fn custom_from_str_example() {
     #[derive(FromArgs)]
     /// Goofy thing.


### PR DESCRIPTION
This removes the restriction against deriving a struct with FromArgs that takes generic arguments, and adds a test to make sure it works correctly. There isn't really a good reason for this constraint as far as I can tell, and it's surprising if you run into it.