### PR TITLE
Allow `#[argh(switch)]` on Option<bool> fields

### DIFF
--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -799,6 +799,16 @@ impl Flag for bool {
     }
 }
 
+impl Flag for Option<bool> {
+    fn default() -> Self {
+        None
+    }
+
+    fn set_flag(&mut self) {
+        *self = Some(true);
+    }
+}
+
 macro_rules! impl_flag_for_integers {
     ($($ty:ty,)*) => {
         $(

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -17,7 +17,7 @@ use {
     proc_macro2::{Span, TokenStream},
     quote::{quote, quote_spanned, ToTokens},
     std::{collections::HashMap, str::FromStr},
-    syn::{spanned::Spanned, LitStr},
+    syn::{spanned::Spanned, GenericArgument, LitStr, PathArguments, Type},
 };
 
 mod errors;
@@ -850,6 +850,16 @@ fn ty_expect_switch(errors: &Errors, ty: &syn::Type) -> bool {
                 return false;
             }
             let ident = &path.path.segments[0].ident;
+            // `Option<bool>` can be used as a `switch`.
+            if ident == "Option" {
+                if let PathArguments::AngleBracketed(args) = &path.path.segments[0].arguments {
+                    if let GenericArgument::Type(Type::Path(p)) = &args.args[0] {
+                        if p.path.segments[0].ident == "bool" {
+                            return true;
+                        }
+                    }
+                }
+            }
             ["bool", "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128"]
                 .iter()
                 .any(|path| ident == path)
@@ -860,7 +870,7 @@ fn ty_expect_switch(errors: &Errors, ty: &syn::Type) -> bool {
 
     let res = ty_can_be_switch(ty);
     if !res {
-        errors.err(ty, "switches must be of type `bool` or integer type");
+        errors.err(ty, "switches must be of type `bool`, `Option<bool>`, or integer type");
     }
     res
 }


### PR DESCRIPTION
It can be useful to use Option<bool> in a configuration struct, in particular if that struct can be built from another source (e.g. deserialized from a configuration file) where boolean switches can be explicitly set to false and we want to differenciate between the flag being negated explicitly from it not being specified.

Thus, allow the `switch` parameters to be used on Option<bool> fields. The field will be `None` if the switch was not specified, and `Some(true)` if it was.