### PR TITLE
Add support for an `hidden_help` attribute 

### DIFF
--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -294,7 +294,7 @@
 //! Programs that are run from an environment such as cargo may find it
 //! useful to have positional arguments present in the structure but
 //! omitted from the usage output. This can be accomplished by adding
-//! the `omit_usage` attribute to that argument:
+//! the `hidden_help` attribute to that argument:
 //!
 //! ```rust
 //! # use argh::FromArgs;
@@ -304,10 +304,10 @@
 //! struct CargoArgs {
 //!     // Cargo puts the command name invoked into the first argument,
 //!     // so we don't want this argument to show up in the usage text.
-//!     #[argh(positional, omit_usage)]
+//!     #[argh(positional, hidden_help)]
 //!     command: String,
 //!     /// an option used for internal debugging
-//!     #[argh(option, omit_usage)]
+//!     #[argh(option, hidden_help)]
 //!     internal_debugging: String,
 //!     #[argh(positional)]
 //!     real_first_arg: String,

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -300,12 +300,15 @@
 //! # use argh::FromArgs;
 //!
 //! #[derive(FromArgs)]
-//! ///
+//! /// Cargo arguments
 //! struct CargoArgs {
 //!     // Cargo puts the command name invoked into the first argument,
 //!     // so we don't want this argument to show up in the usage text.
 //!     #[argh(positional, omit_usage)]
 //!     command: String,
+//!     /// an option used for internal debugging
+//!     #[argh(option, omit_usage)]
+//!     internal_debugging: String,
 //!     #[argh(positional)]
 //!     real_first_arg: String,
 //! }

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -290,6 +290,26 @@
 //!     }
 //! }
 //! ```
+//!
+//! Programs that are run from an environment such as cargo may find it
+//! useful to have positional arguments present in the structure but
+//! omitted from the usage output. This can be accomplished by adding
+//! the `omit_usage` attribute to that argument:
+//!
+//! ```rust
+//! # use argh::FromArgs;
+//!
+//! #[derive(FromArgs)]
+//! ///
+//! struct CargoArgs {
+//!     // Cargo puts the command name invoked into the first argument,
+//!     // so we don't want this argument to show up in the usage text.
+//!     #[argh(positional, omit_usage)]
+//!     command: String,
+//!     #[argh(positional)]
+//!     real_first_arg: String,
+//! }
+//! ```
 
 #![deny(missing_docs)]
 

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -1185,11 +1185,19 @@ Options:
             #[argh(positional)]
             /// this one is real
             _two: String,
+            /// this one should be hidden
+            #[argh(option, omit_usage)]
+            _three: String,
         }
 
         assert_help_string::<Cmd>(
             r###"Usage: test_arg_0 <_two>
+
 Short description
+
+Positional Arguments:
+  _two              this one is real
+
 Options:
   --help            display usage information
 "###,

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -1173,6 +1173,28 @@ Options:
 "###,
         );
     }
+
+    #[test]
+    fn omit_usage_attribute() {
+        #[derive(FromArgs)]
+        /// Short description
+        struct Cmd {
+            /// this one should be hidden
+            #[argh(positional, omit_usage)]
+            _one: String,
+            #[argh(positional)]
+            /// this one is real
+            _two: String,
+        }
+
+        assert_help_string::<Cmd>(
+            r###"Usage: test_arg_0 <_two>
+Short description
+Options:
+  --help            display usage information
+"###,
+        );
+    }
 }
 
 #[test]

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -1175,18 +1175,18 @@ Options:
     }
 
     #[test]
-    fn omit_usage_attribute() {
+    fn hidden_help_attribute() {
         #[derive(FromArgs)]
         /// Short description
         struct Cmd {
             /// this one should be hidden
-            #[argh(positional, omit_usage)]
+            #[argh(positional, hidden_help)]
             _one: String,
             #[argh(positional)]
             /// this one is real
             _two: String,
             /// this one should be hidden
-            #[argh(option, omit_usage)]
+            #[argh(option, hidden_help)]
             _three: String,
         }
 

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -31,7 +31,7 @@ pub(crate) fn help(
     let mut format_lit = "Usage: {command_name}".to_string();
 
     let positional = fields.iter().filter(|f| {
-        f.kind == FieldKind::Positional && f.attrs.greedy.is_none() && !f.attrs.omit_usage
+        f.kind == FieldKind::Positional && f.attrs.greedy.is_none() && !f.attrs.hidden_help
     });
     let mut has_positional = false;
     for arg in positional.clone() {
@@ -40,14 +40,14 @@ pub(crate) fn help(
         positional_usage(&mut format_lit, arg);
     }
 
-    let options = fields.iter().filter(|f| f.long_name.is_some() && !f.attrs.omit_usage);
+    let options = fields.iter().filter(|f| f.long_name.is_some() && !f.attrs.hidden_help);
     for option in options.clone() {
         format_lit.push(' ');
         option_usage(&mut format_lit, option);
     }
 
     let remain = fields.iter().filter(|f| {
-        f.kind == FieldKind::Positional && f.attrs.greedy.is_some() && !f.attrs.omit_usage
+        f.kind == FieldKind::Positional && f.attrs.greedy.is_some() && !f.attrs.hidden_help
     });
     for arg in remain {
         format_lit.push(' ');

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -30,8 +30,9 @@ pub(crate) fn help(
     #![allow(clippy::format_push_string)]
     let mut format_lit = "Usage: {command_name}".to_string();
 
-    let positional =
-        fields.iter().filter(|f| f.kind == FieldKind::Positional && f.attrs.greedy.is_none());
+    let positional = fields.iter().filter(|f| {
+        f.kind == FieldKind::Positional && f.attrs.greedy.is_none() && !f.attrs.omit_usage
+    });
     let mut has_positional = false;
     for arg in positional.clone() {
         has_positional = true;

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -40,14 +40,15 @@ pub(crate) fn help(
         positional_usage(&mut format_lit, arg);
     }
 
-    let options = fields.iter().filter(|f| f.long_name.is_some());
+    let options = fields.iter().filter(|f| f.long_name.is_some() && !f.attrs.omit_usage);
     for option in options.clone() {
         format_lit.push(' ');
         option_usage(&mut format_lit, option);
     }
 
-    let remain =
-        fields.iter().filter(|f| f.kind == FieldKind::Positional && f.attrs.greedy.is_some());
+    let remain = fields.iter().filter(|f| {
+        f.kind == FieldKind::Positional && f.attrs.greedy.is_some() && !f.attrs.omit_usage
+    });
     for arg in remain {
         format_lit.push(' ');
         positional_usage(&mut format_lit, arg);

--- a/argh_derive/src/parse_attrs.rs
+++ b/argh_derive/src/parse_attrs.rs
@@ -19,6 +19,7 @@ pub struct FieldAttrs {
     pub short: Option<syn::LitChar>,
     pub arg_name: Option<syn::LitStr>,
     pub greedy: Option<syn::Path>,
+    pub omit_usage: bool,
 }
 
 /// The purpose of a particular field on a `#![derive(FromArgs)]` struct.
@@ -123,13 +124,15 @@ impl FieldAttrs {
                     );
                 } else if name.is_ident("greedy") {
                     this.greedy = Some(name.clone());
+                } else if name.is_ident("omit_usage") {
+                    this.omit_usage = true;
                 } else {
                     errors.err(
                         &meta,
                         concat!(
                             "Invalid field-level `argh` attribute\n",
                             "Expected one of: `arg_name`, `default`, `description`, `from_str_fn`, `greedy`, ",
-                            "`long`, `option`, `short`, `subcommand`, `switch`",
+                            "`long`, `option`, `short`, `subcommand`, `switch`, `omit_usage`",
                         ),
                     );
                 }

--- a/argh_derive/src/parse_attrs.rs
+++ b/argh_derive/src/parse_attrs.rs
@@ -19,7 +19,7 @@ pub struct FieldAttrs {
     pub short: Option<syn::LitChar>,
     pub arg_name: Option<syn::LitStr>,
     pub greedy: Option<syn::Path>,
-    pub omit_usage: bool,
+    pub hidden_help: bool,
 }
 
 /// The purpose of a particular field on a `#![derive(FromArgs)]` struct.
@@ -124,15 +124,15 @@ impl FieldAttrs {
                     );
                 } else if name.is_ident("greedy") {
                     this.greedy = Some(name.clone());
-                } else if name.is_ident("omit_usage") {
-                    this.omit_usage = true;
+                } else if name.is_ident("hidden_help") {
+                    this.hidden_help = true;
                 } else {
                     errors.err(
                         &meta,
                         concat!(
                             "Invalid field-level `argh` attribute\n",
                             "Expected one of: `arg_name`, `default`, `description`, `from_str_fn`, `greedy`, ",
-                            "`long`, `option`, `short`, `subcommand`, `switch`, `omit_usage`",
+                            "`long`, `option`, `short`, `subcommand`, `switch`, `hidden_help`",
                         ),
                     );
                 }


### PR DESCRIPTION
This PR allows hiding the help for some of the options.

It is based on #75, which is updated to match the latest changes.

Closes #73
Closes #75

