### PR TITLE
Allow to disable requirement for uncapitalized descriptions

### DIFF
--- a/argh/examples/simple_example.rs
+++ b/argh/examples/simple_example.rs
@@ -6,7 +6,12 @@ use {argh::FromArgs, std::fmt::Debug};
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// Top-level command.
+#[argh(lax_descriptions)]
 struct TopLevel {
+    /// Foo
+    #[argh(switch)]
+    common: bool,
+
     #[argh(subcommand)]
     nested: MySubCommandEnum,
 }

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -313,6 +313,24 @@
 //!     real_first_arg: String,
 //! }
 //! ```
+//! 
+//! Programs that are not designed to conform to the Fuchsia commandline tools
+//! specification may find the requirement for descriptions to begin with a
+//! lowercase letter too restrictive. This can be disabled by adding the
+//! `lax_descriptions` attribute to the type:
+//! 
+//! ```rust,no_run
+//! use argh::FromArgs;
+//!
+//! #[derive(FromArgs)]
+//! #[argh(lax_descriptions)]
+//! /// Reach new heights.
+//! struct GoUp {
+//!     /// Now you can capitalize descriptions.
+//!     #[argh(switch, short = 'j')]
+//!     jump: bool,
+//! }
+//! ```
 
 #![deny(missing_docs)]
 

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -285,6 +285,21 @@ struct DescriptionStartsWithInitialism {
     x: u8,
 }
 
+/// Test that descriptions can start with any case when
+/// the type attribute `lax_descriptions` is specified.
+#[derive(FromArgs)]
+#[argh(lax_descriptions)]
+#[allow(unused)]
+struct LaxDescription {
+    /// Don't be so strict.
+    #[argh(option)]
+    x: u8,
+
+    /// don't be so strict.
+    #[argh(option)]
+    y: u8,
+}
+
 #[test]
 fn default_number() {
     #[derive(FromArgs)]

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -259,7 +259,7 @@ fn impl_from_args_struct(
         .named
         .iter()
         .filter_map(|field| {
-            let attrs = FieldAttrs::parse(errors, field);
+            let attrs = FieldAttrs::parse(errors, field, type_attrs);
             StructField::new(errors, field, attrs)
         })
         .collect();


### PR DESCRIPTION
This strict requirement makes sense only for programs designed for Fuchsia, no other system has this convention.

This commit adds a type-level attribute `lax_description` that disables the option descriptions validation when present.