### PR TITLE
fix: correct syn required minimal version

### DIFF
--- a/argh_derive/Cargo.toml
+++ b/argh_derive/Cargo.toml
@@ -14,5 +14,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
+syn = "1.0.3"
 argh_shared = { version = "0.1.10", path = "../argh_shared" }


### PR DESCRIPTION
argh_derive calls `Path.get_ident()` which was introduced in syn 1.0.3, so `syn = "1.0"` causes a minimal version check to fail.

Found via a minimal version check in a downstream library.