### PR TITLE
Disable a pedantic clippy lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Run clippy
-      run: cargo clippy --version && cargo clippy --tests --workspace -- -D warnings
+      run: cargo clippy --version && cargo clippy --tests --workspace -- -D warnings -A clippy::needless-raw-string-hashes
 
   docs:
     name: docs


### PR DESCRIPTION
This lint seems to nickel-and-dime people about string formatting in a way I don't find helpful.