### PR TITLE
Improve error message for invalid long names

### DIFF
--- a/argh/tests/ui/bad-long-names/bad-long-names.rs
+++ b/argh/tests/ui/bad-long-names/bad-long-names.rs
@@ -5,9 +5,9 @@ struct Cmd {
     /// non-ascii
     привет: bool,
     #[argh(switch)]
-    /// uppercase
+    /// invalid character
     XMLHTTPRequest: bool,
-    #[argh(switch, long = "not really")]
+    #[argh(switch, long = "invalid_character")]
     /// bad attr
     ok: bool,
 }

--- a/argh/tests/ui/bad-long-names/bad-long-names.stderr
+++ b/argh/tests/ui/bad-long-names/bad-long-names.stderr
@@ -4,14 +4,14 @@ error: Long names must be ASCII
 6 |     привет: bool,
   |     ^^^^^^
 
-error: Long names must be lowercase
+error: Long names may only contain lowercase letters, digits, and dashes
  --> tests/ui/bad-long-names/bad-long-names.rs:9:5
   |
 9 |     XMLHTTPRequest: bool,
   |     ^^^^^^^^^^^^^^
 
-error: Long names must be lowercase
+error: Long names may only contain lowercase letters, digits, and dashes
   --> tests/ui/bad-long-names/bad-long-names.rs:10:27
    |
-10 |     #[argh(switch, long = "not really")]
-   |                           ^^^^^^^^^^^^
+10 |     #[argh(switch, long = "invalid_character")]
+   |                           ^^^^^^^^^^^^^^^^^^^

--- a/argh_derive/src/parse_attrs.rs
+++ b/argh_derive/src/parse_attrs.rs
@@ -201,7 +201,7 @@ pub(crate) fn check_long_name(errors: &Errors, spanned: &impl syn::spanned::Span
         errors.err(spanned, "Long names must be ASCII");
     }
     if !value.chars().all(|c| c.is_lowercase() || c == '-' || c.is_ascii_digit()) {
-        errors.err(spanned, "Long names must be lowercase");
+        errors.err(spanned, "Long names may only contain lowercase letters, digits, and dashes");
     }
 }
 


### PR DESCRIPTION
This PR improves the error message for invalid long names by accurately stating which characters are permitted

Fixes #99 