### PR TITLE
Add command-line-interface category

### DIFF
--- a/argh/Cargo.toml
+++ b/argh/Cargo.toml
@@ -3,6 +3,7 @@ name = "argh"
 version = "0.1.12"
 authors = ["Taylor Cramer <cramertj@google.com>", "Benjamin Brittain <bwb@google.com>", "Erick Tryzelaar <etryzelaar@google.com>"]
 edition = "2018"
+categories = ["command-line-interface"]
 keywords = ["args", "arguments", "derive", "cli"]
 license = "BSD-3-Clause"
 description = "Derive-based argument parser optimized for code size"


### PR DESCRIPTION
When choosing a command-line parser many people link to the https://crates.io/categories/command-line-interface category. This change adds argh to that category.

I nearly missed argh when looking for a command line parser. Hopefully this helps make it slightly more discoverable.