### PR TITLE
`argh_shared`: change serde features to allow `no_std` use

### DIFF
--- a/argh_shared/Cargo.toml
+++ b/argh_shared/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/google/argh"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }


### PR DESCRIPTION
The `argh_shared` crate depends on `serde`, which uses `std` in its default configuration. This makes it incompatible with `no_std` crates.

As per the [`serde` docs](https://serde.rs/no-std.html), adding `default-features = false` makes it support `no_std`, and adding the `alloc` feature lets it opt back into memory allocation so it can still handle `String`s and such, which is (probably) important here.

This could probably also be accomplished by adding a default-on `std` feature that could be turned off by `no_std` users, but since `argh`'s stated goal is small code size it seemed like defaulting to `no_std`-compatibility was the sanest & simplest change.