### PR TITLE
Call unraw() on idents

### DIFF
--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -317,6 +317,20 @@ fn explicit_long_value_for_option() {
     assert_eq!(cmd.x, 5);
 }
 
+#[test]
+fn raw_identifier() {
+    #[derive(FromArgs, Debug)]
+    /// Short description
+    struct Cmd {
+        #[argh(switch)]
+        /// whether to move the file
+        r#move: bool,
+    }
+
+    let cmd = Cmd::from_args(&["cmdname"], &["--move"]).unwrap();
+    assert!(cmd.r#move);
+}
+
 /// Test that descriptions can start with an initialism despite
 /// usually being required to start with a lowercase letter.
 #[derive(FromArgs)]

--- a/argh_derive/src/lib.rs
+++ b/argh_derive/src/lib.rs
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+use syn::ext::IdentExt as _;
+
 /// Implementation of the `FromArgs` and `argh(...)` derive attributes.
 ///
 /// For more thorough documentation, see the `argh` crate itself.
@@ -188,7 +190,7 @@ impl<'a> StructField<'a> {
         let long_name = match kind {
             FieldKind::Switch | FieldKind::Option => {
                 let long_name = attrs.long.as_ref().map(syn::LitStr::value).unwrap_or_else(|| {
-                    let kebab_name = to_kebab_case(&name.to_string());
+                    let kebab_name = to_kebab_case(&name.unraw().to_string());
                     check_long_name(errors, name, &kebab_name);
                     kebab_name
                 });


### PR DESCRIPTION
This changes argh_derive to allow using raw struct field identifiers (e.g., `r#move`) as long names.

Closes #124

For the reference, other crates' derive macros, e.g., [serde](https://github.com/serde-rs/serde/issues/1362) and [clap](https://github.com/clap-rs/clap/blob/v4.4.18/tests/derive/raw_idents.rs) allow them.