### PR TITLE
A few help and error reporting improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /argh_derive/target/
 /argh_shared/target/
 /target/
+/research

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 /argh_derive/target/
 /argh_shared/target/
 /target/
-/research

--- a/argh/examples/help_text_example.rs
+++ b/argh/examples/help_text_example.rs
@@ -1,0 +1,66 @@
+use argh::{FromArgs, TopLevelCommand};
+
+#[derive(FromArgs)]
+/// Defines a rectangle
+#[argh(verbose_error, help_triggers("-h", "--help"))] 
+pub struct Rectangle {
+    #[argh(option, short = 'w')]
+    /// width; 23 if omitted
+    pub width: Option<u32>,
+
+    #[argh(option, short = 'h')]
+    /// height; 42 if omitted
+    pub height: Option<u32>,
+
+    #[argh(switch)]
+    /// print extended help and exit
+    pub long_help: bool,
+
+    #[argh(help_text)]
+    pub usage: Option<String>,
+}
+
+impl Rectangle {
+    fn check(&mut self) -> Result<(), String> {
+        if self.width.is_none() {
+            self.width = Some(23);
+        }
+        if self.height.is_none() {
+            self.height = Some(42);
+        }
+        let w64: u64 = self.width.unwrap().into();
+        let h64: u64 = self.height.unwrap().into();
+        let area = w64 * h64;
+        if area > 0xFFFFFFFF {
+            Err(String::from("You asked for too big a rectangle"))
+        } else {
+            return Ok(());
+        }
+    }
+}
+
+fn main() {
+    let mut rect: Rectangle = argh::from_env();
+    if let Err(msg) = rect.check() {
+        rect.report_error_and_exit(&msg)
+    }
+    if rect.long_help {
+        println!(
+            "{}\n\n{}",
+            rect.usage.unwrap(),
+            "Definition:
+  In Euclidean plane geometry, a rectangle is a quadrilateral with
+  four right angles. It can also be defined as: an equiangular
+  quadrilateral, since equiangular means that all of its angles are
+  equal (360°/4 = 90°); or a parallelogram containing a right angle.
+  A rectangle with four sides of equal length is a square. The term
+  “oblong” is used to refer to a non-square rectangle.
+
+  According to Wikipedia as of mid April 2024",
+        )
+    } else {
+        let w = rect.width.unwrap();
+        let h = rect.height.unwrap();
+        println!("Rectangle area is: {}={}x{}", w * h, w, h);
+    }
+}

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -603,6 +603,11 @@ pub trait FromArgs: Sized {
     fn redact_arg_values(_command_name: &[&str], _args: &[&str]) -> Result<Vec<String>, EarlyExit> {
         Ok(vec!["<<REDACTED>>".into()])
     }
+
+    #[doc(hidden)]
+    fn cook_help_text(_command_name: &[&str]) -> Option<String> {
+        None
+    }
 }
 
 /// A top-level `FromArgs` implementation that is not a subcommand.

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -611,7 +611,10 @@ pub trait FromArgs: Sized {
 }
 
 /// A top-level `FromArgs` implementation that is not a subcommand.
-pub trait TopLevelCommand: FromArgs {}
+pub trait TopLevelCommand: FromArgs {
+    #[doc(hidden)]
+    fn report_error(_bin_name: &str, msg: &str);    
+}
 
 /// A `FromArgs` implementation that can parse into one or more subcommands.
 pub trait SubCommands: FromArgs {
@@ -718,7 +721,7 @@ pub fn from_env<T: TopLevelCommand>() -> T {
                 0
             }
             Err(()) => {
-                eprintln!("{}\nRun {} --help for more information.", early_exit.output, cmd);
+                T::report_error(cmd, &early_exit.output);
                 1
             }
         })
@@ -744,7 +747,7 @@ pub fn cargo_from_env<T: TopLevelCommand>() -> T {
                 0
             }
             Err(()) => {
-                eprintln!("{}\nRun --help for more information.", early_exit.output);
+                T::report_error(cmd, &early_exit.output);
                 1
             }
         })

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -612,8 +612,85 @@ pub trait FromArgs: Sized {
 
 /// A top-level `FromArgs` implementation that is not a subcommand.
 pub trait TopLevelCommand: FromArgs {
+    /// Prints error message and usage informaton to STDERR and exits with elevated 
+    /// exit code. Handy when arguments combination needs to be checked for 
+    /// consistency. Use together with ‘verbose_error’ attribute to garmonize internal 
+    /// error reporting style.
+    /// 
+    /// # Example
+    /// 
+    /// ```rust
+    /// use argh::{FromArgs, TopLevelCommand};
+    /// 
+    /// #[derive(FromArgs)]
+    /// /// Defines a rectangle
+    /// #[argh(verbose_error, help_triggers("-h", "--help"))] 
+    /// pub struct Rectangle {
+    ///     #[argh(option, short = 'w')]
+    ///     /// width; 23 if omitted
+    ///     pub width: Option<u32>,
+    /// 
+    ///     #[argh(option, short = 'h')]
+    ///     /// height; 42 if omitted
+    ///     pub height: Option<u32>,
+    /// 
+    ///     #[argh(switch)]
+    ///     /// print extended help and exit
+    ///     pub long_help: bool,
+    /// 
+    ///     #[argh(help_text)]
+    ///     pub usage: Option<String>,
+    /// }
+    /// 
+    /// impl Rectangle {
+    ///     fn check(&mut self) -> Result<(), String> {
+    ///         if self.width.is_none() {
+    ///             self.width = Some(23);
+    ///         }
+    ///         if self.height.is_none() {
+    ///             self.height = Some(42);
+    ///         }
+    ///         let w64: u64 = self.width.unwrap().into();
+    ///         let h64: u64 = self.height.unwrap().into();
+    ///         let area = w64 * h64;
+    ///         if area > 0xFFFFFFFF {
+    ///             Err(String::from("You asked for too big a rectangle"))
+    ///         } else {
+    ///             return Ok(());
+    ///         }
+    ///     }
+    /// }
+    /// 
+    /// fn main() {
+    ///     let mut rect: Rectangle = argh::from_env();
+    ///     if let Err(msg) = rect.check() {
+    ///         rect.report_error_and_exit(&msg)
+    ///     }
+    ///     if rect.long_help {
+    ///         println!(
+    ///             "{}\n\n{}",
+    ///             rect.usage.unwrap(),
+    ///             "Definition:
+    ///   In Euclidean plane geometry, a rectangle is a quadrilateral with
+    ///   four right angles. It can also be defined as: an equiangular
+    ///   quadrilateral, since equiangular means that all of its angles are
+    ///   equal (360°/4 = 90°); or a parallelogram containing a right angle.
+    ///   A rectangle with four sides of equal length is a square. The term
+    ///   “oblong” is used to refer to a non-square rectangle.
+    /// 
+    ///   According to Wikipedia as of mid April 2024",
+    ///         )
+    ///     } else {
+    ///         let w = rect.width.unwrap();
+    ///         let h = rect.height.unwrap();
+    ///         println!("Rectangle area is: {}={}x{}", w * h, w, h);
+    ///     }
+    /// }
+    /// ```
+    fn report_error_and_exit(&self, msg: &str);
+
     #[doc(hidden)]
-    fn report_error(_bin_name: &str, msg: &str);    
+    fn cook_error_report(_bin_name: &str, msg: &str) -> String;
 }
 
 /// A `FromArgs` implementation that can parse into one or more subcommands.
@@ -721,7 +798,7 @@ pub fn from_env<T: TopLevelCommand>() -> T {
                 0
             }
             Err(()) => {
-                T::report_error(cmd, &early_exit.output);
+                eprint!("{}", T::cook_error_report(cmd, &early_exit.output));
                 1
             }
         })
@@ -747,7 +824,7 @@ pub fn cargo_from_env<T: TopLevelCommand>() -> T {
                 0
             }
             Err(()) => {
-                T::report_error(cmd, &early_exit.output);
+                eprint!("{}", T::cook_error_report(cmd, &early_exit.output));
                 1
             }
         })
@@ -996,8 +1073,16 @@ impl<'a> ParseStructOptions<'a> {
                     .ok_or_else(|| ["No value provided for option '", arg, "'.\n"].concat())?;
                 *remaining_args = &remaining_args[1..];
                 pvs.fill_slot(arg, value).map_err(|s| {
-                    ["Error parsing option '", arg, "' with value '", value, "': ", &s, "\n"]
-                        .concat()
+                    [
+                        "Cannot parse option '", 
+                        arg, 
+                        "' with value '", 
+                        value, 
+                        "': ", 
+                        &s, 
+                        "\n"
+                    ]
+                    .concat()
                 })?;
             }
         }
@@ -1087,7 +1172,7 @@ impl<'a> ParseStructPositional<'a> {
     fn parse(&mut self, arg: &str) -> Result<(), EarlyExit> {
         self.slot.fill_slot("", arg).map_err(|s| {
             [
-                "Error parsing positional argument '",
+                "Cannot parse positional argument '",
                 self.name,
                 "' with value '",
                 arg,

--- a/argh_derive/src/args_info.rs
+++ b/argh_derive/src/args_info.rs
@@ -312,7 +312,8 @@ fn impl_args_info_data<'a>(
                     }
                 });
             }
-            FieldKind::SubCommand => {}
+            FieldKind::SubCommand 
+                | FieldKind::HelpText => {}
         }
     }
 

--- a/argh_derive/src/help.rs
+++ b/argh_derive/src/help.rs
@@ -130,10 +130,10 @@ pub(crate) fn help(
 
     format_lit.push('\n');
 
-    quote! { {
+    quote! {
         #subcommand_calculation
-        format!(#format_lit, command_name = #cmd_name_str_array_ident.join(" "), #subcommand_format_arg)
-    } }
+        Some(format!(#format_lit, command_name = #cmd_name_str_array_ident.join(" "), #subcommand_format_arg))
+    }
 }
 
 /// A section composed of exactly just the literals provided to the program.
@@ -190,7 +190,10 @@ fn option_usage(out: &mut String, field: &StructField<'_>) {
     }
 
     match field.kind {
-        FieldKind::SubCommand | FieldKind::Positional => unreachable!(), // don't have long_name
+        FieldKind::SubCommand 
+            | FieldKind::HelpText
+            | FieldKind::Positional 
+                => unreachable!("subcommand, help_text and positional have no long names"),
         FieldKind::Switch => {}
         FieldKind::Option => {
             out.push_str(" <");

--- a/argh_derive/src/parse_attrs.rs
+++ b/argh_derive/src/parse_attrs.rs
@@ -700,7 +700,6 @@ pub fn check_enum_type_attrs(errors: &Errors, type_attrs: &TypeAttrs, type_span:
             err_unused_enum_attr(errors, trigger);
         }
     }
-    // TODO: Test
     if *verbose_error {
         err_unused_enum_attr(errors, verbose_error);
     }


### PR DESCRIPTION
Hi!

I've added a few features related to help and error reporting:
1. a new ‘help_text’ attribute that denotes a pseudo-argumen containing the generated help – it comes handy if you need to construct “long help”;
1. a new TopLevelCommand instance method ‘report_error_and_exit‘ – helps with reporting higher level errors / inconsistencies in (combinations of) arguments;
1. a new ‘verbose_error‘ attribute – it harmonizes the internal error reporting style with ‘report_error_and_exit‘ output for UI consistency.

I've included an example utilising all of these additions at `argh/examples/help_text_example.rs`, please check it out.

Hope you find it useful.