### PR TITLE
Remove once_cell dependency preferring LazyLock

### DIFF
--- a/argh/Cargo.toml
+++ b/argh/Cargo.toml
@@ -16,7 +16,6 @@ argh_derive.workspace = true
 rust-fuzzy-search = "0.1.1"
 
 [dev-dependencies]
-once_cell = "1.10.0"
 trybuild = "1.0.63"
 
 [features]

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -206,7 +206,7 @@
 //! # use argh::DynamicSubCommand;
 //! # use argh::EarlyExit;
 //! # use argh::FromArgs;
-//! # use once_cell::sync::OnceCell;
+//! # use std::sync::LazyLock;
 //!
 //! #[derive(FromArgs, PartialEq, Debug)]
 //! /// Top-level command.
@@ -240,8 +240,7 @@
 //!
 //! impl DynamicSubCommand for Dynamic {
 //!     fn commands() -> &'static [&'static CommandInfo] {
-//!         static RET: OnceCell<Vec<&'static CommandInfo>> = OnceCell::new();
-//!         RET.get_or_init(|| {
+//!         static RET: LazyLock<Vec<&'static CommandInfo>> = LazyLock::new(|| {
 //!             let mut commands = Vec::new();
 //!
 //!             // argh needs the `CommandInfo` structs we generate to be valid
@@ -257,7 +256,8 @@
 //!             })));
 //!
 //!             commands
-//!         })
+//!         });
+//!         &RET
 //!     }
 //!
 //!     fn try_redact_arg_values(


### PR DESCRIPTION
## Change Summary

`once_cell`'s features were stabilized and included in the standard library under the std::sync module. We can use `LazyLock` to have the same behaviour as `OnceCell::get_or_init`.

With this change, we reduce the dependencies further, even though the removal happens on the `dev-dependencies` scope.

## Risks associated with this change
The only risk that comes to mind is that without `once_cell`, we expect users developing `argh` (using the `dev-dependencies`) to use the 1.80.0+ Rust version.

## Testing

`cargo nextest run && cargo t --doc` with all tests passing.
