### PR TITLE
Implement choice enums

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
       run: cargo test --workspace --verbose
 
     - name: Run simple_example
-      run: cargo run --package argh --example simple_example two --fooey
+      run: cargo run --package argh --example simple_example two --fooey --woot quiet
 
   rustfmt:
     name: rustfmt

--- a/argh/examples/simple_example.rs
+++ b/argh/examples/simple_example.rs
@@ -34,6 +34,16 @@ struct SubCommandTwo {
     #[argh(switch)]
     /// whether to fooey
     fooey: bool,
+
+    #[argh(option)]
+    /// how to woot
+    woot: Woot,
+}
+
+#[derive(argh::FromArgValue, PartialEq, Debug)]
+enum Woot {
+    Quiet,
+    Loud,
 }
 
 fn main() {

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -319,7 +319,7 @@
 
 use std::str::FromStr;
 
-pub use argh_derive::{ArgsInfo, FromArgs};
+pub use argh_derive::{ArgsInfo, FromArgValue, FromArgs};
 
 /// Information about a particular command used for output.
 pub type CommandInfo = argh_shared::CommandInfo<'static>;

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -111,6 +111,28 @@
 //! }
 //! ```
 //!
+//! `FromArgValue` can be automatically derived for `enum`s, with automatic
+//! error messages:
+//!
+//! ```
+//! use argh::{FromArgs, FromArgValue};
+//!
+//! #[derive(FromArgValue)]
+//! struct Mode {
+//!     SoftCore,
+//!     HardCore,
+//! }
+//!
+//! #[derive(FromArgs)]
+//! struct DoIt {
+//!     #[argh(option)]
+//!     how: Mode,
+//! }
+//!
+//! // ./some_bin --how whatever
+//! // > Error parsing option '--how' with value 'whatever': expected "soft_core" or "hard_core"
+//! ```
+//!
 //! Positional arguments can be declared using `#[argh(positional)]`.
 //! These arguments will be parsed in order of their declaration in
 //! the structure:
@@ -751,7 +773,7 @@ pub fn cargo_from_env<T: TopLevelCommand>() -> T {
 /// Any field type declared in a struct that derives `FromArgs` must implement
 /// this trait. A blanket implementation exists for types implementing
 /// `FromStr<Error: Display>`. Custom types can implement this trait
-/// directly.
+/// directly. It can also be derived on plain `enum`s without associated data.
 pub trait FromArgValue: Sized {
     /// Construct the type from a commandline value, returning an error string
     /// on failure.

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -118,14 +118,16 @@
 //! use argh::{FromArgs, FromArgValue};
 //!
 //! #[derive(FromArgValue)]
-//! struct Mode {
+//! enum Mode {
 //!     SoftCore,
 //!     HardCore,
 //! }
 //!
 //! #[derive(FromArgs)]
+//! /// Do the thing.
 //! struct DoIt {
 //!     #[argh(option)]
+//!     /// how to do it
 //!     how: Mode,
 //! }
 //!

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -546,6 +546,7 @@ Options:
     #[derive(FromArgValue, PartialEq, Debug)]
     enum ThreeChoices {
         FirstChoice,
+        #[argh(name = "に")]
         Two,
         Three,
     }
@@ -575,10 +576,18 @@ Options:
     }
 
     #[test]
+    fn with_name_override() {
+        assert_output(
+            &["--choice2", "に", "--choice1", "hola"],
+            WithChoices { choice1: TwoChoices::Hola, choice2: ThreeChoices::Two },
+        )
+    }
+
+    #[test]
     fn invalid_choice() {
         assert_error::<WithChoices>(
             &["--choice2", "something"],
-            r###"Error parsing option '--choice2' with value 'something': expected "first_choice", "two" or "three"
+            r###"Error parsing option '--choice2' with value 'something': expected "first_choice", "に" or "three"
 "###,
         )
     }

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -11,7 +11,10 @@
     clippy::unwrap_in_result
 )]
 
-use {argh::FromArgs, std::fmt::Debug};
+use {
+    argh::{FromArgValue, FromArgs},
+    std::fmt::Debug,
+};
 
 #[test]
 fn basic_example() {
@@ -518,6 +521,78 @@ Woot
 
 Options:
   --option-name     fooey
+  --help, help      display usage information
+"###,
+        );
+    }
+
+    /// Test choices
+    #[derive(FromArgs, PartialEq, Debug)]
+    struct WithChoices {
+        /// first choice with a default
+        #[argh(option, default = "TwoChoices::Chao")]
+        choice1: TwoChoices,
+        /// second choice.
+        #[argh(option)]
+        choice2: ThreeChoices,
+    }
+
+    #[derive(FromArgValue, PartialEq, Debug)]
+    enum TwoChoices {
+        Hola,
+        Chao,
+    }
+
+    #[derive(FromArgValue, PartialEq, Debug)]
+    enum ThreeChoices {
+        FirstChoice,
+        Two,
+        Three,
+    }
+
+    #[test]
+    fn with_choices() {
+        assert_output(
+            &["--choice2", "three"],
+            WithChoices { choice1: TwoChoices::Chao, choice2: ThreeChoices::Three },
+        );
+    }
+
+    #[test]
+    fn with_choices_snake_case() {
+        assert_output(
+            &["--choice2", "first_choice"],
+            WithChoices { choice1: TwoChoices::Chao, choice2: ThreeChoices::FirstChoice },
+        )
+    }
+
+    #[test]
+    fn override_default() {
+        assert_output(
+            &["--choice2", "first_choice", "--choice1", "hola"],
+            WithChoices { choice1: TwoChoices::Hola, choice2: ThreeChoices::FirstChoice },
+        )
+    }
+
+    #[test]
+    fn invalid_choice() {
+        assert_error::<WithChoices>(
+            &["--choice2", "something"],
+            r###"Error parsing option '--choice2' with value 'something': expected "first_choice", "two" or "three"
+"###,
+        )
+    }
+
+    #[test]
+    fn choice_help() {
+        assert_help_string::<WithChoices>(
+            r###"Usage: test_arg_0 [--choice1 <choice1>] --choice2 <choice2>
+
+Test choices
+
+Options:
+  --choice1         first choice with a default
+  --choice2         second choice.
   --help, help      display usage information
 "###,
         );


### PR DESCRIPTION
This PR implements #138.

Basically, it allows using simple fieldless enums as arguments by deriving `FromArgValue`:

```rust
#[derive(FromArgValue)]
enum MyChoiceEnum {
    Black,
    Yellow,
}

#[derive(FromArgs)]
struct Args {
    #[argh(option)]
    color: MyChoiceEnum,
}
```

Additionally:

- I convert the `PascalCase` names of enum variants into `snake_case`, so that the code above could be run as `./some_bin --color black` or `./some_bin --color yellow`.

- `#[argh(name = "arbitrary_name")` attributes are allowed to specify any desired name for each variant.

- I implemented better error messages like `Error parsing option '--color' with value 'purple': expected "black" or "yellow"`

- I did **not** implement listing available options in the help message, because that would require some heavier refactoring and I am not very familiar with the codebase yet.

- I added some basic documentation to the `lib.rs` top-level doc-comment, to the simple example and to the `FromArgValue` trait, as well as tests.