### PR TITLE
Make dependency on rust-fuzzy-search optional (#197)

### DIFF
--- a/argh/Cargo.toml
+++ b/argh/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 argh_shared.workspace = true
 argh_derive.workspace = true
-rust-fuzzy-search = "0.1.1"
+rust-fuzzy-search = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0.63"

--- a/argh/src/lib.rs
+++ b/argh/src/lib.rs
@@ -356,6 +356,7 @@ pub type SubCommandInfo = argh_shared::SubCommandInfo<'static>;
 
 pub use argh_shared::{ErrorCodeInfo, FlagInfo, FlagInfoKind, Optionality, PositionalInfo};
 
+#[cfg(feature = "rust-fuzzy-search")]
 use rust_fuzzy_search::fuzzy_search_best_n;
 
 /// Structured information about the command line arguments.
@@ -1038,8 +1039,17 @@ fn unrecognized_argument(
         return format!("Unrecognized argument: \"{}\"\n", given);
     }
 
-    let suggestions = fuzzy_search_best_n(given, &available, 1);
-    format!("Unrecognized argument: \"{}\". Did you mean \"{}\"?\n", given, suggestions[0].0)
+    #[cfg(feature = "rust-fuzzy-search")]
+    {
+        let suggestions = fuzzy_search_best_n(given, &available, 1);
+        return format!(
+            "Unrecognized argument: \"{}\". Did you mean \"{}\"?\n",
+            given, suggestions[0].0
+        );
+    }
+
+    #[cfg(not(feature = "rust-fuzzy-search"))]
+    ["Unrecognized argument: ", given, "\n"].concat()
 }
 
 // `--` or `-` options, including a mutable reference to their value.

--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -1009,7 +1009,10 @@ mod fuchsia_commandline_tools_rubric {
 
         let e = OneOption::from_args(&["cmdname"], &["--foo=bar"])
             .expect_err("Parsing option value using `=` should fail");
+        #[cfg(feature = "rust-fuzzy-search")]
         assert_eq!(e.output, "Unrecognized argument: \"--foo=bar\". Did you mean \"--foo\"?\n");
+        #[cfg(not(feature = "rust-fuzzy-search"))]
+        assert_eq!(e.output, "Unrecognized argument: --foo=bar\n");
         assert!(e.status.is_err());
     }
 


### PR DESCRIPTION
Updates the lib and tests to make the dependency on rust-fuzzy-search optional, allowing for smaller binaries if the feature is not needed.

Fixes: #197