### PR TITLE
Add attributes to configure usage line in --help

### DIFF
--- a/argh/tests/lib.rs
+++ b/argh/tests/lib.rs
@@ -631,7 +631,7 @@ mod positional {
             LastRepeating { a: 5, b: vec!["foo".into(), "bar".into()] },
         );
         assert_help_string::<LastRepeating>(
-            r###"Usage: test_arg_0 <a> [<b...>]
+            r###"Usage: test_arg_0 [--] <a> [<b...>]
 
 Woot
 
@@ -714,7 +714,7 @@ Options:
             },
         );
         assert_help_string::<LastRepeatingGreedy>(
-            r###"Usage: test_arg_0 <a> [--b] [--c <c>] [d...]
+            r###"Usage: test_arg_0 [--b] [--c <c>] [--] <a> [d...]
 
 Woot
 
@@ -1368,7 +1368,7 @@ Error codes:
     #[test]
     fn with_arg_name() {
         assert_help_string::<WithArgName>(
-            r###"Usage: test_arg_0 <name>
+            r###"Usage: test_arg_0 [--] <name>
 
 Destroy the contents of <file>.
 
@@ -1398,7 +1398,7 @@ Options:
         }
 
         assert_help_string::<Cmd>(
-            r###"Usage: test_arg_0 <two>
+            r###"Usage: test_arg_0 [--] <two>
 
 Short description
 
@@ -1883,4 +1883,57 @@ fn long_alphanumeric() {
 
     let cmd = Cmd::from_args(&["cmdname"], &["--ac97", "bar"]).unwrap();
     assert_eq!(cmd.ac97, "bar");
+}
+
+#[test]
+fn override_usage() {
+    /// Height options
+    #[derive(FromArgs)]
+    #[argh(help_triggers("-h", "--help", "help"))]
+    #[argh(usage = "USAGE LINE")]
+    struct Height {
+        /// how high to go
+        #[argh(option)]
+        _height: usize,
+    }
+
+    assert_help_string::<Height>(
+        r#"Usage: test_arg_0 USAGE LINE
+
+Height options
+
+Options:
+  --height          how high to go
+  -h, --help, help  display usage information
+"#,
+    );
+}
+
+#[test]
+fn customize_usage() {
+    /// Height options
+    #[derive(FromArgs)]
+    #[argh(help_triggers("-h", "--help", "help"))]
+    struct Height {
+        /// how high to go
+        #[argh(option)]
+        #[argh(usage)]
+        _height: usize,
+
+        /// hidden from usage
+        #[argh(option)]
+        _hidden: usize,
+    }
+
+    assert_help_string::<Height>(
+        r#"Usage: test_arg_0 --height <height>
+
+Height options
+
+Options:
+  --height          how high to go
+  --hidden          hidden from usage
+  -h, --help, help  display usage information
+"#,
+    );
 }


### PR DESCRIPTION
Consider the cargo build as an example:

```
$ cargo build --help
Usage: cargo build [OPTIONS]

Options:
      --future-incompat-report  Outputs a future incompatibility report at the end of the build
      --message-format <FMT>    Error format
  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
  -q, --quiet                   Do not print cargo log messages
      --color <WHEN>            Coloring: auto, always, never
      --config <KEY=VALUE>      Override a configuration value
  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
  -h, --help                    Print help
...
```

Currently with how argh generate usage line this would look like:

```
Usage: cargo build [--future-incompat-report] [--message-format <fmt>] [-v] [-q] [--color <when>] [--config <key=value>] [-Z <flag>]
...
```

It's too long, barely readable, and also looks terrible when it gets split in multiple lines by the terminal. And there's no option around it.

We already provide an exhausting information in help. So I suggest adding an option to only outline the most useful parameters in usage, for example the following:

```
Usage: cargo build [-v] [-q] [--bin <name>] [--release]
```

This is done by adding `usage` attribute to fields we want to see in usage, other option are then hidden from the usage line by default.

```rust
#[derive(FromArgs)]
struct CliArgs {
...
    #[argh(option)]
    #[argh(usage)] // <--
    release: bool,
...
}
```

There is also a catch-all option to override the usage line entirely, so it's possible to reproduce what cargo build command has.

```rust
#[derive(FromArgs)]
#[argh(usage = "[OPTIONS]")] // <--
struct CliArgs {
...
}
```

Producing:

```
Usage: cargo build [OPTIONS]
```

I also rearranged components in the generated usage line and added a `[--]` hint. Previously positional arguments went first before options, which is kinda misleading, since positionals may themselves start with `-`.

So without subcommand it's now `[options...] [--] [positional...]` and with it `[options...] [positional...] [subcommand...]`.

The fuchsia cli guide doesn't specify on this. And I hasn't found any reason for why it wasn't that way before.
