### PR TITLE
doc: Fix typo on subcommand example

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ struct SubCommandOne {
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// Second subcommand.
-#[argh(subcommand, name = "two", short = "t")]
+#[argh(subcommand, name = "two", short = 't')]
 struct SubCommandTwo {
     #[argh(switch)]
     /// whether to fooey


### PR DESCRIPTION
Before:
<img width="2011" height="463" alt="image" src="https://github.com/user-attachments/assets/8c229448-4899-4560-8bf2-b02f8209c2e4" />

After:
<img width="931" height="434" alt="image" src="https://github.com/user-attachments/assets/cc500a10-21b6-44ae-94f8-885a2b67adb7" />


